### PR TITLE
fix: PR#84 レビュー指摘対応 - 固定長入力でuseFirstRowAsHeaderが正しく適用されない問題を修正

### DIFF
--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -135,14 +135,20 @@ const handleFixedWidthInput = (lengths: number[], data: string) => {
   // 固定長 → TSV/CSV/md-tbl/html-tbl/固定長
   const parsedData = parseFixed(data, lengths)
 
+  // useFirstRowAsHeaderがtrueの場合、1行目をスキップ
+  let dataRows = parsedData
+  if (useFirstRowAsHeader.value) {
+    dataRows = parsedData.slice(1)
+  }
+
   // columnHeadersがある場合は先頭に追加
-  let dataWithHeaders = parsedData
+  let dataWithHeaders = dataRows
   if (columnHeaders.value.trim() && !useFirstRowAsHeader.value) {
     const headerDelimiter = getDelimiter(columnHeaders.value, 'auto')
     const headers = headerDelimiter === '|'
       ? parsePipe(columnHeaders.value)[0]
       : parseDelimitedData(columnHeaders.value, headerDelimiter)[0]
-    dataWithHeaders = [headers, ...parsedData]
+    dataWithHeaders = [headers, ...dataRows]
   }
 
   if (outputFormat.value === 'fixed') {

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -135,20 +135,17 @@ const handleFixedWidthInput = (lengths: number[], data: string) => {
   // 固定長 → TSV/CSV/md-tbl/html-tbl/固定長
   const parsedData = parseFixed(data, lengths)
 
-  // useFirstRowAsHeaderがtrueの場合、1行目をスキップ
-  let dataRows = parsedData
+  let processedData = parsedData
   if (useFirstRowAsHeader.value) {
-    dataRows = parsedData.slice(1)
+    processedData = processedData.slice(1)
   }
 
-  // columnHeadersがある場合は先頭に追加
-  let dataWithHeaders = dataRows
   if (columnHeaders.value.trim() && !useFirstRowAsHeader.value) {
     const headerDelimiter = getDelimiter(columnHeaders.value, 'auto')
     const headers = headerDelimiter === '|'
       ? parsePipe(columnHeaders.value)[0]
       : parseDelimitedData(columnHeaders.value, headerDelimiter)[0]
-    dataWithHeaders = [headers, ...dataRows]
+    processedData = [headers, ...processedData]
   }
 
   if (outputFormat.value === 'fixed') {
@@ -156,17 +153,17 @@ const handleFixedWidthInput = (lengths: number[], data: string) => {
     const options = columnOptions.value.trim()
       ? parseColumnOptions(columnOptions.value)
       : lengths.map(() => ({ type: 'string' as const, padding: 'right' as const, padChar: ' ' }))
-    fullResult.value = convertTsvToFixed(dataWithHeaders, lengths, options)
+    fullResult.value = convertTsvToFixed(processedData, lengths, options)
   } else if (outputFormat.value === 'md-tbl') {
     conversionType.value = '固定長 → md-tbl'
-    fullResult.value = toMarkdown(dataWithHeaders)
+    fullResult.value = toMarkdown(processedData)
   } else if (outputFormat.value === 'html-tbl') {
     conversionType.value = '固定長 → html-tbl'
-    fullResult.value = toHtmlTable(dataWithHeaders)
+    fullResult.value = toHtmlTable(processedData)
   } else {
     const outputType = outputFormat.value === 'csv' ? 'CSV' : 'TSV'
     conversionType.value = `固定長 → ${outputType}`
-    fullResult.value = outputFormat.value === 'csv' ? toCSV(dataWithHeaders, forceAllString.value) : toTSV(dataWithHeaders, forceAllString.value)
+    fullResult.value = outputFormat.value === 'csv' ? toCSV(processedData, forceAllString.value) : toTSV(processedData, forceAllString.value)
   }
 }
 


### PR DESCRIPTION
## 概要

PR#84のレビュー指摘に対応しました。

## 対応内容

### 指摘: 「1行目をヘッダーとして使用」オプションが固定長入力データに適用されていない

**問題**:
- `useFirstRowAsHeader`が`true`の場合、`columnHeaders`は追加されないが、`parsedData`の最初の行が削除されていなかった
- `handleDelimitedInput`では`parsedData.slice(1)`が適用されているため、固定長入力でも同様の処理が必要

**修正内容**:
- `handleFixedWidthInput`関数で`useFirstRowAsHeader`が`true`の場合、`parsedData.slice(1)`で最初の行をスキップする処理を追加

## 関連PR

- 元のPR: #84

## テスト

- [x] ビルド成功確認
- [x] 全テスト成功（284件）

コミット: a05b95b

🤖 Generated with [Claude Code](https://claude.com/claude-code)