### PR TITLE
feat: プリセット機能追加とUI改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tmp/
 # Build artifacts
 *.tsbuildinfo
 tasks/
+
+# Playwright MCP
+.playwright-mcp/

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,7 @@
+[tasks."dev:stop"]
+description = "Stop dev server on port 40101"
+run = "kill $(lsof -ti:40101) 2>/dev/null || true"
+
+[tasks."dev:restart"]
+description = "Restart dev server"
+run = ["mise dev:stop", "npm run dev"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## mise tasks
+
+mise tasksでコマンドを追加できる。

--- a/__tests__/views/FixedLengthConverter.test.ts
+++ b/__tests__/views/FixedLengthConverter.test.ts
@@ -260,11 +260,13 @@ describe('FixedLengthConverter.vue', () => {
     it('should allow delimiter type selection', async () => {
       const wrapper = createWrapper();
       const store = useConverterStore();
-      
-      const delimiterSelect = wrapper.find('select');
-      if (delimiterSelect.exists()) {
-        await delimiterSelect.setValue('comma');
-        expect(store.delimiterType).toBe('comma');
+
+      // delimiterTypeはラジオボタンで実装されている
+      const radioButtons = wrapper.findAll('input[type="radio"]');
+      const csvRadio = radioButtons.find(r => r.element.value === 'csv');
+      if (csvRadio?.exists()) {
+        await csvRadio.setValue();
+        expect(store.delimiterType).toBe('csv');
       }
     });
   });

--- a/src/composables/usePresetCache.ts
+++ b/src/composables/usePresetCache.ts
@@ -1,0 +1,123 @@
+import { ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useConverterStore } from '../stores/converter'
+
+interface PresetData {
+  columnLengths: string
+  columnHeaders: string
+  columnOptions: string
+  delimiterType: string
+  outputFormat: string
+  forceAllString: boolean
+  useFirstRowAsHeader: boolean
+}
+
+interface StoredPresets {
+  [key: string]: PresetData
+}
+
+const STORAGE_KEY = 'fixed-length-converter-presets'
+
+export function usePresetCache() {
+  const store = useConverterStore()
+  const {
+    columnLengths,
+    columnHeaders,
+    columnOptions,
+    delimiterType,
+    outputFormat,
+    forceAllString,
+    useFirstRowAsHeader
+  } = storeToRefs(store)
+
+  const presetName = ref('')
+  const presets = ref<StoredPresets>({})
+
+  // ローカルストレージからプリセットを読み込み
+  const loadPresets = () => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        presets.value = JSON.parse(stored)
+      }
+    } catch {
+      presets.value = {}
+    }
+  }
+
+  // プリセットをローカルストレージに保存
+  const savePresets = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(presets.value))
+    } catch (e) {
+      console.error('Failed to save presets:', e)
+    }
+  }
+
+  // 現在の設定をプリセットとして保存
+  const saveCurrentAsPreset = (): { success: boolean; message: string } => {
+    const name = presetName.value.trim()
+    if (!name) {
+      return { success: false, message: 'プリセット名を入力してください' }
+    }
+
+    presets.value[name] = {
+      columnLengths: columnLengths.value,
+      columnHeaders: columnHeaders.value,
+      columnOptions: columnOptions.value,
+      delimiterType: delimiterType.value,
+      outputFormat: outputFormat.value,
+      forceAllString: forceAllString.value,
+      useFirstRowAsHeader: useFirstRowAsHeader.value
+    }
+
+    savePresets()
+    return { success: true, message: `プリセット「${name}」を保存しました` }
+  }
+
+  // 指定したプリセットを読み込み
+  const loadPreset = (name: string): { success: boolean; message: string } => {
+    const preset = presets.value[name]
+    if (!preset) {
+      return { success: false, message: 'プリセットが見つかりません' }
+    }
+
+    columnLengths.value = preset.columnLengths
+    columnHeaders.value = preset.columnHeaders
+    columnOptions.value = preset.columnOptions
+    delimiterType.value = preset.delimiterType as typeof delimiterType.value
+    outputFormat.value = preset.outputFormat as typeof outputFormat.value
+    forceAllString.value = preset.forceAllString
+    useFirstRowAsHeader.value = preset.useFirstRowAsHeader
+
+    presetName.value = name
+    return { success: true, message: `プリセット「${name}」を読み込みました` }
+  }
+
+  // 指定したプリセットを削除
+  const deletePreset = (name: string): { success: boolean; message: string } => {
+    if (!presets.value[name]) {
+      return { success: false, message: 'プリセットが見つかりません' }
+    }
+
+    delete presets.value[name]
+    savePresets()
+
+    if (presetName.value === name) {
+      presetName.value = ''
+    }
+
+    return { success: true, message: `プリセット「${name}」を削除しました` }
+  }
+
+  // 初期化時にプリセットを読み込み
+  loadPresets()
+
+  return {
+    presetName,
+    presets,
+    saveCurrentAsPreset,
+    loadPreset,
+    deletePreset
+  }
+}

--- a/src/composables/usePresetCache.ts
+++ b/src/composables/usePresetCache.ts
@@ -1,13 +1,14 @@
 import { ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConverterStore } from '../stores/converter'
+import type { DelimiterType } from '../utils/converter'
 
 interface PresetData {
   columnLengths: string
   columnHeaders: string
   columnOptions: string
-  delimiterType: string
-  outputFormat: string
+  delimiterType: DelimiterType
+  outputFormat: 'tsv' | 'csv' | 'fixed' | 'md-tbl' | 'html-tbl'
   forceAllString: boolean
   useFirstRowAsHeader: boolean
 }
@@ -38,7 +39,10 @@ export function usePresetCache() {
     try {
       const stored = localStorage.getItem(STORAGE_KEY)
       if (stored) {
-        presets.value = JSON.parse(stored)
+        const parsed = JSON.parse(stored)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          presets.value = parsed
+        }
       }
     } catch {
       presets.value = {}
@@ -59,6 +63,17 @@ export function usePresetCache() {
     const name = presetName.value.trim()
     if (!name) {
       return { success: false, message: 'プリセット名を入力してください' }
+    }
+
+    // 同名のプリセットが存在する場合は上書き確認
+    if (presets.value[name]) {
+      const overwrite = window.confirm(
+        `プリセット「${name}」は既に存在します。上書き保存しますか？`
+      )
+
+      if (!overwrite) {
+        return { success: false, message: '保存をキャンセルしました' }
+      }
     }
 
     presets.value[name] = {
@@ -85,8 +100,8 @@ export function usePresetCache() {
     columnLengths.value = preset.columnLengths
     columnHeaders.value = preset.columnHeaders
     columnOptions.value = preset.columnOptions
-    delimiterType.value = preset.delimiterType as typeof delimiterType.value
-    outputFormat.value = preset.outputFormat as typeof outputFormat.value
+    delimiterType.value = preset.delimiterType
+    outputFormat.value = preset.outputFormat
     forceAllString.value = preset.forceAllString
     useFirstRowAsHeader.value = preset.useFirstRowAsHeader
 

--- a/src/style.css
+++ b/src/style.css
@@ -589,3 +589,104 @@ textarea:disabled {
 .table-name-input {
   font-size: 1rem !important;
 }
+
+/* プリセットセクション */
+.preset-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 20px;
+  padding: 12px 16px;
+  background-color: var(--bg-tertiary);
+  border-radius: 6px;
+  border: 1px solid var(--border-color-light);
+}
+
+.preset-input {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 250px;
+}
+
+.preset-name-input {
+  flex: 1;
+  min-width: 150px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 14px;
+  background-color: var(--input-bg);
+  color: var(--text-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.preset-name-input:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.preset-select {
+  min-width: 150px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-size: 14px;
+  background-color: var(--input-bg);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+}
+
+.preset-select:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.preset-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-small {
+  padding: 6px 12px;
+  font-size: 13px;
+  border-radius: 4px;
+  gap: 4px;
+}
+
+.btn-small i {
+  font-size: 16px;
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+  color: white;
+}
+
+.btn-danger:hover:not(:disabled) {
+  box-shadow: 0 4px 8px rgba(231, 76, 60, 0.4);
+}
+
+@media (max-width: 768px) {
+  .preset-section {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .preset-input {
+    flex-direction: column;
+  }
+
+  .preset-name-input,
+  .preset-select {
+    width: 100%;
+  }
+
+  .preset-actions {
+    justify-content: flex-end;
+  }
+}
+

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -7,6 +7,7 @@ import { parseDelimitedData, parsePipe, toCSV, toTSV, toMarkdown, toHtmlTable } 
 import { useNotification } from '../composables/useNotification'
 import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
 import { useFileUpload } from '../composables/useFileUpload'
+import { usePresetCache } from '../composables/usePresetCache'
 
 const store = useConverterStore()
 const { columnLengths, columnHeaders, columnOptions, delimiterType, outputFormat, forceAllString, useFirstRowAsHeader } = storeToRefs(store)
@@ -22,6 +23,50 @@ const fullResult = ref('')
 
 const { notificationMessage, notificationType, showNotificationFlag, showNotification } = useNotification()
 const { displayResult } = useTruncatedDisplay(fullResult)
+
+// プリセットキャッシュ機能
+const {
+  presetName,
+  presets,
+  saveCurrentAsPreset,
+  loadPreset,
+  deletePreset
+} = usePresetCache()
+
+const selectedPreset = ref('')
+
+const handleSavePreset = () => {
+  const result = saveCurrentAsPreset()
+  showNotification(result.message, result.success ? 'success' : 'error')
+  if (result.success) {
+    selectedPreset.value = presetName.value
+  }
+}
+
+const handleLoadPreset = () => {
+  if (!selectedPreset.value) {
+    showNotification('読み込むプリセットを選択してください', 'error')
+    return
+  }
+  const result = loadPreset(selectedPreset.value)
+  showNotification(result.message, result.success ? 'success' : 'error')
+}
+
+const handleDeletePreset = () => {
+  if (!selectedPreset.value) {
+    showNotification('削除するプリセットを選択してください', 'error')
+    return
+  }
+  const result = deletePreset(selectedPreset.value)
+  showNotification(result.message, result.success ? 'success' : 'error')
+  if (result.success) {
+    selectedPreset.value = ''
+  }
+}
+
+const presetOptions = computed(() => {
+  return Object.keys(presets.value)
+})
 
 // ファイルアップロード機能
 const {
@@ -298,6 +343,36 @@ const clearDataBody = () => {
       </div>
     </div>
 
+    <div class="preset-section">
+      <div class="preset-input">
+        <input
+          type="text"
+          v-model="presetName"
+          placeholder="プリセット名"
+          class="preset-name-input"
+        />
+        <select v-model="selectedPreset" class="preset-select">
+          <option value="">選択...</option>
+          <option v-for="name in presetOptions" :key="name" :value="name">
+            {{ name }}
+          </option>
+        </select>
+      </div>
+      <div class="preset-actions">
+        <button class="btn btn-small" @click="handleSavePreset" title="現在の設定を保存">
+          <i class="mdi mdi-content-save"></i>
+          保存
+        </button>
+        <button class="btn btn-small" @click="handleLoadPreset" :disabled="!selectedPreset" title="選択したプリセットを読み込み">
+          <i class="mdi mdi-folder-open"></i>
+          読込
+        </button>
+        <button class="btn btn-small btn-danger" @click="handleDeletePreset" :disabled="!selectedPreset" title="選択したプリセットを削除">
+          <i class="mdi mdi-delete"></i>
+        </button>
+      </div>
+    </div>
+
     <div class="input-section">
       <div class="input-header">
         <div class="input-actions">
@@ -341,13 +416,6 @@ const clearDataBody = () => {
           />
           <button
             class="btn btn-icon-small"
-            @click="uploadFile"
-            title="ファイルから読み込み"
-          >
-            <i class="mdi mdi-file-upload"></i>
-          </button>
-          <button
-            class="btn btn-icon-small"
             @click="copyFieldToClipboard(displayDataBody, 'データ本体')"
             :disabled="!hasDataBody"
             title="コピー"
@@ -368,6 +436,13 @@ const clearDataBody = () => {
             title="クリア"
           >
             <i class="mdi mdi-delete"></i>
+          </button>
+          <button
+            class="btn btn-icon-small"
+            @click="uploadFile"
+            title="ファイルから読み込み"
+          >
+            <i class="mdi mdi-file-upload"></i>
           </button>
         </div>
         <h3>データ本体</h3>


### PR DESCRIPTION
## 変更内容

- プリセット機能: テキストボックス + ドロップダウン + 保存/読込/削除ボタン
- uploadボタンの位置をtrashボタンの右に移動
- mise tasksにdev:stop, dev:restartを追加
- .gitignoreに.playwright-mcp/を追加

## テスト

- [x] 手動テスト完了

## 確認事項

- [ ] コードレビュー依頼済み
- [ ] CIパス確認