### PR TITLE
fix: PR#87 レビュー指摘対応 + 入力形式検証とUI改善

### DIFF
--- a/src/composables/usePresetCache.ts
+++ b/src/composables/usePresetCache.ts
@@ -1,14 +1,14 @@
 import { ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConverterStore } from '../stores/converter'
-import type { DelimiterType } from '../utils/converter'
+import type { DelimiterType, OutputFormat } from '../utils/converter'
 
 interface PresetData {
   columnLengths: string
   columnHeaders: string
   columnOptions: string
   delimiterType: DelimiterType
-  outputFormat: 'tsv' | 'csv' | 'fixed' | 'md-tbl' | 'html-tbl'
+  outputFormat: OutputFormat
   forceAllString: boolean
   useFirstRowAsHeader: boolean
 }
@@ -97,13 +97,13 @@ export function usePresetCache() {
       return { success: false, message: 'プリセットが見つかりません' }
     }
 
-    columnLengths.value = preset.columnLengths
-    columnHeaders.value = preset.columnHeaders
-    columnOptions.value = preset.columnOptions
-    delimiterType.value = preset.delimiterType
-    outputFormat.value = preset.outputFormat
-    forceAllString.value = preset.forceAllString
-    useFirstRowAsHeader.value = preset.useFirstRowAsHeader
+    columnLengths.value = preset.columnLengths ?? ''
+    columnHeaders.value = preset.columnHeaders ?? ''
+    columnOptions.value = preset.columnOptions ?? ''
+    delimiterType.value = preset.delimiterType ?? 'auto'
+    outputFormat.value = preset.outputFormat ?? 'tsv'
+    forceAllString.value = preset.forceAllString ?? false
+    useFirstRowAsHeader.value = preset.useFirstRowAsHeader ?? false
 
     presetName.value = name
     return { success: true, message: `プリセット「${name}」を読み込みました` }

--- a/src/stores/converter.ts
+++ b/src/stores/converter.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { DelimiterType } from '../utils/converter'
+import type { DelimiterType, OutputFormat } from '../utils/converter'
 
 export const useConverterStore = defineStore('converter', () => {
   const columnLengths = ref('')
@@ -8,7 +8,7 @@ export const useConverterStore = defineStore('converter', () => {
   const columnHeaders = ref('')
   const columnOptions = ref('')
   const delimiterType = ref<DelimiterType>('auto')
-  const outputFormat = ref<'tsv' | 'csv' | 'fixed' | 'md-tbl' | 'html-tbl'>('tsv')
+  const outputFormat = ref<OutputFormat>('tsv')
   const forceAllString = ref(false)
   const useFirstRowAsHeader = ref(false)
 

--- a/src/style.css
+++ b/src/style.css
@@ -690,3 +690,83 @@ textarea:disabled {
   }
 }
 
+/* 変換行（変換ボタン + 形式選択） */
+.conversion-row {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+}
+
+.format-selectors {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.format-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background-color: var(--bg-tertiary);
+  border-radius: 6px;
+  border: 1px solid var(--border-color-light);
+  flex-wrap: wrap;
+}
+
+.format-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  margin-right: 4px;
+}
+
+.format-option {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--btn-icon-text);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 3px;
+  transition: background-color 0.2s ease;
+}
+
+.format-option:hover {
+  background-color: var(--btn-icon-hover);
+}
+
+.format-option input[type="radio"] {
+  cursor: pointer;
+  margin: 0;
+  accent-color: #667eea;
+}
+
+.format-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: 20px;
+}
+
+@media (max-width: 900px) {
+  .conversion-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .format-selectors {
+    justify-content: center;
+  }
+
+  .format-arrow {
+    transform: rotate(90deg);
+  }
+}
+

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -8,6 +8,8 @@ export interface ColumnOption {
 
 export type DelimiterType = 'auto' | 'tsv' | 'csv' | 'fixed' | 'pipe'
 
+export type OutputFormat = 'tsv' | 'csv' | 'fixed' | 'md-tbl' | 'html-tbl'
+
 // Unicode正規表現定数
 const UNICODE_SPACE_REGEX = /[\u00A0\u2000-\u200A\u202F\u205F]/g
 const UNICODE_CONTROL_REGEX = /[\u00AD\u200B-\u200F]/g

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -101,12 +101,25 @@ void fileInputRef // テンプレートで使用されるが、スクリプト�
 
 const hasDataBody = computed(() => !!(uploadedFile.value || store.dataBody))
 
-const isDelimitedData = (data: string, expectedColumnCount: number): string[][] | false => {
+type ParseResult = { data: string[][] } | { error: string }
+
+const isDelimitedData = (data: string, expectedColumnCount: number): ParseResult | false => {
   // 固定長として明示的に指定されている場合は区切り文字データとして扱わない
   if (delimiterType.value === 'fixed') return false
-  
+
   const trimmedData = data.trim().replace(/\r\n/g, '\n').replace(/\r/g, '\n')
   if (trimmedData.length === 0) return false
+
+  // 明示的な形式が指定されている場合、その区切り文字がデータに含まれているか検証
+  if (delimiterType.value !== 'auto') {
+    const expectedDelimiter = delimiterType.value === 'tsv' ? '\t' : delimiterType.value === 'csv' ? ',' : '|'
+    const hasExpectedDelimiter = trimmedData.includes(expectedDelimiter)
+
+    if (!hasExpectedDelimiter) {
+      const formatName = delimiterType.value === 'tsv' ? 'TSV' : delimiterType.value === 'csv' ? 'CSV' : 'SQL/MD表'
+      return { error: `入力形式が「${formatName}」に設定されていますが、${formatName === 'CSV' ? 'カンマ' : formatName === 'TSV' ? 'タブ' : 'パイプ'}が見つかりません。入力形式を見直してください。` }
+    }
+  }
 
   try {
     const delimiter = getDelimiter(trimmedData, delimiterType.value)
@@ -133,7 +146,7 @@ const isDelimitedData = (data: string, expectedColumnCount: number): string[][] 
     if (firstColumnCount === 1 && expectedColumnCount !== 1) return false
 
     // パース成功時は全行を返す
-    return allRows
+    return { data: allRows }
   } catch {
     // パースに失敗した場合は区切り文字データではないと判断
     return false
@@ -243,9 +256,14 @@ const convert = async () => {
 
     // まず区切り文字データかどうか判定（カラム長は後で確認）
     const lengths = parseColumnLengths(columnLengths.value)
-    const parsedData = isDelimitedData(data, lengths.length || 1)
-    
-    if (parsedData) {
+    const parseResult = isDelimitedData(data, lengths.length || 1)
+
+    // エラーがある場合は表示して終了
+    if (parseResult && 'error' in parseResult) {
+      throw new Error(parseResult.error)
+    }
+
+    if (parseResult && 'data' in parseResult) {
       // 区切り文字データ（TSV/CSV/SQL表）の場合
       // 固定長への変換時のみカラム長が必要
       if (outputFormat.value === 'fixed') {
@@ -253,7 +271,7 @@ const convert = async () => {
           throw new Error('固定長への変換にはカラム長が必要です')
         }
       }
-      handleDelimitedInput(lengths, parsedData, data)
+      handleDelimitedInput(lengths, parseResult.data, data)
     } else {
       // 固定長データの場合は必ずカラム長が必要
       if (lengths.length === 0) {
@@ -331,28 +349,6 @@ const clearDataBody = () => {
   <div class="converter-container">
     <div class="header-row">
       <h2>固定長相互変換</h2>
-      <div class="delimiter-selector">
-        <label>
-          <input type="radio" value="auto" v-model="delimiterType" />
-          自動判別
-        </label>
-        <label>
-          <input type="radio" value="tsv" v-model="delimiterType" />
-          TSV
-        </label>
-        <label>
-          <input type="radio" value="csv" v-model="delimiterType" />
-          CSV
-        </label>
-        <label>
-          <input type="radio" value="pipe" v-model="delimiterType" />
-          SQL/MD表
-        </label>
-        <label>
-          <input type="radio" value="fixed" v-model="delimiterType" />
-          固定長
-        </label>
-      </div>
     </div>
 
     <div class="preset-section">
@@ -565,9 +561,9 @@ const clearDataBody = () => {
       </div>
     </div>
 
-    <div class="button-group">
-      <button 
-        class="btn btn-primary" 
+    <div class="conversion-row">
+      <button
+        class="btn btn-primary"
         @click="convert"
         :disabled="convertLoading"
         :class="{ loading: convertLoading }"
@@ -575,6 +571,58 @@ const clearDataBody = () => {
         <i class="mdi mdi-auto-fix"></i>
         <span>変換</span>
       </button>
+
+      <div class="format-selectors">
+        <div class="format-group">
+          <span class="format-label">入力:</span>
+          <label class="format-option">
+            <input type="radio" value="auto" v-model="delimiterType" />
+            自動
+          </label>
+          <label class="format-option">
+            <input type="radio" value="tsv" v-model="delimiterType" />
+            TSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="csv" v-model="delimiterType" />
+            CSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="pipe" v-model="delimiterType" />
+            SQL/MD
+          </label>
+          <label class="format-option">
+            <input type="radio" value="fixed" v-model="delimiterType" />
+            固定長
+          </label>
+        </div>
+
+        <span class="format-arrow"><i class="mdi mdi-arrow-right"></i></span>
+
+        <div class="format-group">
+          <span class="format-label">出力:</span>
+          <label class="format-option">
+            <input type="radio" value="fixed" v-model="outputFormat" />
+            固定長
+          </label>
+          <label class="format-option">
+            <input type="radio" value="tsv" v-model="outputFormat" />
+            TSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="csv" v-model="outputFormat" />
+            CSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="md-tbl" v-model="outputFormat" />
+            md-tbl
+          </label>
+          <label class="format-option">
+            <input type="radio" value="html-tbl" v-model="outputFormat" />
+            html-tbl
+          </label>
+        </div>
+      </div>
     </div>
 
     <div class="result-section">
@@ -602,31 +650,6 @@ const clearDataBody = () => {
         <h3>実行結果<span v-if="conversionType" class="conversion-type">（{{ conversionType }}）</span></h3>
       </div>
       <textarea :value="displayResult" rows="10" readonly :placeholder="resultPlaceholder"></textarea>
-      <div class="result-actions">
-        <div class="output-format-selector">
-          <label>出力形式:</label>
-          <label>
-            <input type="radio" value="fixed" v-model="outputFormat" />
-            固定長
-          </label>
-          <label>
-            <input type="radio" value="tsv" v-model="outputFormat" />
-            TSV
-          </label>
-          <label>
-            <input type="radio" value="csv" v-model="outputFormat" />
-            CSV
-          </label>
-          <label>
-            <input type="radio" value="md-tbl" v-model="outputFormat" />
-            md-tbl
-          </label>
-          <label>
-            <input type="radio" value="html-tbl" v-model="outputFormat" />
-            html-tbl
-          </label>
-        </div>
-      </div>
     </div>
 
     <!-- 通知メッセージ -->

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -34,6 +34,7 @@ const {
 } = usePresetCache()
 
 const selectedPreset = ref('')
+const deleteConfirming = ref(false)
 
 const handleSavePreset = () => {
   const result = saveCurrentAsPreset()
@@ -57,11 +58,22 @@ const handleDeletePreset = () => {
     showNotification('削除するプリセットを選択してください', 'error')
     return
   }
+
+  // 2段階削除: 最初のクリックで確認状態、2回目で削除
+  if (!deleteConfirming.value) {
+    deleteConfirming.value = true
+    setTimeout(() => {
+      deleteConfirming.value = false
+    }, 3000)
+    return
+  }
+
   const result = deletePreset(selectedPreset.value)
   showNotification(result.message, result.success ? 'success' : 'error')
   if (result.success) {
     selectedPreset.value = ''
   }
+  deleteConfirming.value = false
 }
 
 const presetOptions = computed(() => {
@@ -367,8 +379,15 @@ const clearDataBody = () => {
           <i class="mdi mdi-folder-open"></i>
           読込
         </button>
-        <button class="btn btn-small btn-danger" @click="handleDeletePreset" :disabled="!selectedPreset" title="選択したプリセットを削除">
-          <i class="mdi mdi-delete"></i>
+        <button
+          class="btn btn-small"
+          :class="deleteConfirming ? 'btn-danger' : ''"
+          @click="handleDeletePreset"
+          :disabled="!selectedPreset"
+          :title="deleteConfirming ? 'もう一度クリックして削除' : '選択したプリセットを削除'"
+        >
+          <i class="mdi" :class="deleteConfirming ? 'mdi-alert' : 'mdi-delete'"></i>
+          <span v-if="deleteConfirming">?</span>
         </button>
       </div>
     </div>

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -34,7 +34,7 @@ const {
 } = usePresetCache()
 
 const selectedPreset = ref('')
-const deleteConfirming = ref(false)
+const confirmingDeletePresetName = ref('')
 
 const handleSavePreset = () => {
   const result = saveCurrentAsPreset()
@@ -60,10 +60,12 @@ const handleDeletePreset = () => {
   }
 
   // 2段階削除: 最初のクリックで確認状態、2回目で削除
-  if (!deleteConfirming.value) {
-    deleteConfirming.value = true
+  if (confirmingDeletePresetName.value !== selectedPreset.value) {
+    confirmingDeletePresetName.value = selectedPreset.value
     setTimeout(() => {
-      deleteConfirming.value = false
+      if (confirmingDeletePresetName.value === selectedPreset.value) {
+        confirmingDeletePresetName.value = ''
+      }
     }, 3000)
     return
   }
@@ -73,7 +75,7 @@ const handleDeletePreset = () => {
   if (result.success) {
     selectedPreset.value = ''
   }
-  deleteConfirming.value = false
+  confirmingDeletePresetName.value = ''
 }
 
 const presetOptions = computed(() => {
@@ -113,7 +115,7 @@ const isDelimitedData = (data: string, expectedColumnCount: number): ParseResult
   // 明示的な形式が指定されている場合、その区切り文字がデータに含まれているか検証
   if (delimiterType.value !== 'auto') {
     const expectedDelimiter = delimiterType.value === 'tsv' ? '\t' : delimiterType.value === 'csv' ? ',' : '|'
-    const hasExpectedDelimiter = trimmedData.includes(expectedDelimiter)
+    const hasExpectedDelimiter = expectedColumnCount === 1 || trimmedData.includes(expectedDelimiter)
 
     if (!hasExpectedDelimiter) {
       const formatName = delimiterType.value === 'tsv' ? 'TSV' : delimiterType.value === 'csv' ? 'CSV' : 'SQL/MD表'
@@ -377,13 +379,13 @@ const clearDataBody = () => {
         </button>
         <button
           class="btn btn-small"
-          :class="deleteConfirming ? 'btn-danger' : ''"
+          :class="confirmingDeletePresetName === selectedPreset ? 'btn-danger' : ''"
           @click="handleDeletePreset"
           :disabled="!selectedPreset"
-          :title="deleteConfirming ? 'もう一度クリックして削除' : '選択したプリセットを削除'"
+          :title="confirmingDeletePresetName === selectedPreset ? 'もう一度クリックして削除' : '選択したプリセットを削除'"
         >
-          <i class="mdi" :class="deleteConfirming ? 'mdi-alert' : 'mdi-delete'"></i>
-          <span v-if="deleteConfirming">?</span>
+          <i class="mdi" :class="confirmingDeletePresetName === selectedPreset ? 'mdi-alert' : 'mdi-delete'"></i>
+          <span v-if="confirmingDeletePresetName === selectedPreset">?</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## 概要

PR#87（dev → main）のレビュー指摘に対応しました。

## 対応内容

### レビュー指摘対応
- **Null合体演算子での防御的実装**: localStorageから読み込まれたデータが不完全な場合にデフォルト値を設定
- **プリセット削除確認**: 2段階削除方式を実装（window.confirm禁止のため代替実装）
- **型定義共通化**: OutputFormat型を共通化して重複を解消

### 追加対応
- **入力形式の検証**: 明示的に形式指定時、データが一致しない場合はエラーメッセージを表示
- **UI改善**: 変換ボタンの右に入力元・出力先形式選択を配置

## 関連PR

- 元のPR: #87

## テスト

- [x] ビルド成功確認
- [x] ユニットテスト全て通過（284件）

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>