### PR TITLE
feat: frame-table入力対応、DelimiterSelector共通化、SQL INSERT自動再生成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Dev Server
+
+- Port: 40100（`vite.config.ts`で設定）
+
 ## mise tasks
 
 mise tasksでコマンドを追加できる。

--- a/__tests__/components/App.test.ts
+++ b/__tests__/components/App.test.ts
@@ -5,6 +5,7 @@ import { createRouter, createMemoryHistory } from 'vue-router';
 import App from '../../src/App.vue';
 import FixedLengthConverter from '../../src/views/FixedLengthConverter.vue';
 import NumberingLineConverter from '../../src/views/NumberingLineConverter.vue';
+import TableTransformer from '../../src/views/TableTransformer.vue';
 import SqlInsertGenerator from '../../src/views/SqlInsertGenerator.vue';
 import SettingsPage from '../../src/views/SettingsPage.vue';
 
@@ -16,6 +17,7 @@ describe('App.vue', () => {
         { path: '/', redirect: '/fixed-length' },
         { path: '/fixed-length', name: 'fixed-length', component: FixedLengthConverter },
         { path: '/numbering-line', name: 'numbering-line', component: NumberingLineConverter },
+        { path: '/table-transform', name: 'table-transform', component: TableTransformer },
         { path: '/sql-insert', name: 'sql-insert', component: SqlInsertGenerator },
         { path: '/settings', name: 'settings', component: SettingsPage },
       ],
@@ -40,11 +42,12 @@ describe('App.vue', () => {
     it('should render all tabs', async () => {
       const wrapper = await createWrapper();
       const tabs = wrapper.findAll('.sidebar-nav li');
-      expect(tabs).toHaveLength(4);
+      expect(tabs).toHaveLength(5);
       expect(tabs[0].text()).toBe('固定長相互変換');
       expect(tabs[1].text()).toBe('ナンバリング行変換');
-      expect(tabs[2].text()).toBe('SQL INSERT文生成');
-      expect(tabs[3].text()).toBe('設定');
+      expect(tabs[2].text()).toBe('表変換');
+      expect(tabs[3].text()).toBe('SQL INSERT文生成');
+      expect(tabs[4].text()).toBe('設定');
     });
 
     it('should have first tab active by default', async () => {

--- a/__tests__/utils/converter.test.ts
+++ b/__tests__/utils/converter.test.ts
@@ -134,6 +134,16 @@ describe('Fixed Length Converter', () => {
       const data = 'test'
       expect(detectDelimiter(data)).toBe('\t')
     })
+
+    it('should detect frame-table format', () => {
+      const data = '┌───────────────┬────────┬────────────┐\n│  Model / Bot  │ AvgPen │ Normalized │\n├───────────────┼────────┼────────────┤\n│ pmc:100:1.0   │ 6.38   │ 2.16       │'
+      expect(detectDelimiter(data)).toBe('│')
+    })
+
+    it('should detect frame-table format with bottom border', () => {
+      const data = '┌────┬──────┐\n│ id │ name │\n├────┼──────┤\n│  1 │ Alice│\n└────┴──────┘'
+      expect(detectDelimiter(data)).toBe('│')
+    })
   })
 
   describe('getDelimiter', () => {
@@ -147,6 +157,10 @@ describe('Fixed Length Converter', () => {
 
     it('should return pipe for pipe type', () => {
       expect(getDelimiter('any data', 'pipe')).toBe('|')
+    })
+
+    it('should return frame delimiter for frame type', () => {
+      expect(getDelimiter('any data', 'frame')).toBe('│')
     })
 
     it('should auto-detect for auto type', () => {

--- a/__tests__/utils/delimited.test.ts
+++ b/__tests__/utils/delimited.test.ts
@@ -242,6 +242,16 @@ describe('Delimited Data Converter', () => {
       expect(result).toEqual([['a', '', 'c']])
     })
 
+    it('全て空セルのデータ行をスキップしない', () => {
+      const input = '┌───┬───┬───┐\n│ a │ b │ c │\n├───┼───┼───┤\n│   │   │   │\n├───┼───┼───┤\n│ d │ e │ f │\n└───┴───┴───┘'
+      const result = parseFrame(input)
+      expect(result).toEqual([
+        ['a', 'b', 'c'],
+        ['', '', ''],
+        ['d', 'e', 'f']
+      ])
+    })
+
     it('ヘッダーなしのframe-tableをパースできる', () => {
       const input = '┌───┬───────┬─────┐\n│ 1 │ Alice │ 100 │\n│ 2 │ Bob   │ 200 │\n└───┴───────┴─────┘'
       const result = parseFrame(input)

--- a/__tests__/utils/delimited.test.ts
+++ b/__tests__/utils/delimited.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { toCSV, toTSV, parseCSV, parseTSV, parsePipe, toPipe, toMarkdown, toHtmlTable } from '../../src/utils/delimited'
+import { toCSV, toTSV, parseCSV, parseTSV, parsePipe, parseFrame, toPipe, toMarkdown, toHtmlTable } from '../../src/utils/delimited'
 
 describe('Delimited Data Converter', () => {
   describe('toCSV', () => {
@@ -206,6 +206,58 @@ describe('Delimited Data Converter', () => {
       expect(result).toEqual([
         ['1', 'Alice', '100'],
         ['2', 'Bob', '200']
+      ])
+    })
+  })
+
+  describe('parseFrame', () => {
+    it('frame-table形式をパースできる', () => {
+      const input = '┌───────────────┬────────┬────────────┐\n│  Model / Bot  │ AvgPen │ Normalized │\n├───────────────┼────────┼────────────┤\n│ pmc:100:1.0   │ 6.38   │ 2.16       │\n├───────────────┼────────┼────────────┤\n│ counting      │ 7.78   │ 1.72       │\n└───────────────┴────────┴────────────┘'
+      const result = parseFrame(input)
+      expect(result).toEqual([
+        ['Model / Bot', 'AvgPen', 'Normalized'],
+        ['pmc:100:1.0', '6.38', '2.16'],
+        ['counting', '7.78', '1.72']
+      ])
+    })
+
+    it('セパレータ行のみのframe-tableをパースできる（データなし）', () => {
+      const input = '┌────┬──────┐\n└────┴──────┘'
+      const result = parseFrame(input)
+      expect(result).toEqual([])
+    })
+
+    it('空行をスキップする', () => {
+      const input = '┌────┬──────┐\n│ id │ name │\n├────┼──────┤\n\n│  1 │ Alice│\n└────┴──────┘'
+      const result = parseFrame(input)
+      expect(result).toEqual([
+        ['id', 'name'],
+        ['1', 'Alice']
+      ])
+    })
+
+    it('空のカラムを含む行を処理できる', () => {
+      const input = '┌───┬───┬───┐\n│ a │   │ c │\n└───┴───┴───┘'
+      const result = parseFrame(input)
+      expect(result).toEqual([['a', '', 'c']])
+    })
+
+    it('ヘッダーなしのframe-tableをパースできる', () => {
+      const input = '┌───┬───────┬─────┐\n│ 1 │ Alice │ 100 │\n│ 2 │ Bob   │ 200 │\n└───┴───────┴─────┘'
+      const result = parseFrame(input)
+      expect(result).toEqual([
+        ['1', 'Alice', '100'],
+        ['2', 'Bob', '200']
+      ])
+    })
+
+    it('末尾セパレータなしのframe-tableをパースできる', () => {
+      const input = '┌────┬──────┐\n│ id │ name │\n├────┼──────┤\n│  1 │ Alice│\n│  2 │ Bob  │'
+      const result = parseFrame(input)
+      expect(result).toEqual([
+        ['id', 'name'],
+        ['1', 'Alice'],
+        ['2', 'Bob']
       ])
     })
   })

--- a/__tests__/utils/delimited.test.ts
+++ b/__tests__/utils/delimited.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { toCSV, toTSV, parseCSV, parseTSV, parsePipe, parseFrame, toPipe, toMarkdown, toHtmlTable } from '../../src/utils/delimited'
+import { toCSV, toTSV, parseCSV, parseTSV, parsePipe, parseFrame, toPipe, toMarkdown, toHtmlTable, toFrame } from '../../src/utils/delimited'
 
 describe('Delimited Data Converter', () => {
   describe('toCSV', () => {
@@ -313,6 +313,36 @@ describe('Delimited Data Converter', () => {
       const lines = result.split('\n')
       expect(lines[0]).toBe('| a   | b   |')
       expect(lines[1]).toBe('| --- | --- |')
+    })
+  })
+
+  describe('toFrame', () => {
+    it('frame-table形式に変換できる', () => {
+      const data = [['id', 'name'], ['1', 'Alice'], ['2', 'Bob']]
+      const result = toFrame(data)
+      const lines = result.split('\n')
+      expect(lines[0]).toBe('┌──┬─────┐')
+      expect(lines[1]).toBe('│id│name │')
+      expect(lines[2]).toBe('├──┼─────┤')
+      expect(lines[3]).toBe('│1 │Alice│')
+      expect(lines[4]).toBe('│2 │Bob  │')
+      expect(lines[5]).toBe('└──┴─────┘')
+    })
+
+    it('空データを処理できる', () => {
+      const data: string[][] = []
+      const result = toFrame(data)
+      expect(result).toBe('')
+    })
+
+    it('1行のみのデータを処理できる（中間罫線なし）', () => {
+      const data = [['a', 'b']]
+      const result = toFrame(data)
+      const lines = result.split('\n')
+      expect(lines[0]).toBe('┌─┬─┐')
+      expect(lines[1]).toBe('│a│b│')
+      expect(lines[2]).toBe('└─┴─┘')
+      expect(lines.length).toBe(3)
     })
   })
 

--- a/__tests__/utils/tableTransform.test.ts
+++ b/__tests__/utils/tableTransform.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { transpose, flipVertical, flipHorizontal } from '../../src/utils/tableTransform'
+
+describe('tableTransform', () => {
+  describe('transpose', () => {
+    it('should transpose a simple 2x3 matrix', () => {
+      const data = [
+        ['a', 'b', 'c'],
+        ['d', 'e', 'f']
+      ]
+      expect(transpose(data)).toEqual([
+        ['a', 'd'],
+        ['b', 'e'],
+        ['c', 'f']
+      ])
+    })
+
+    it('should handle empty array', () => {
+      expect(transpose([])).toEqual([])
+    })
+
+    it('should handle single row', () => {
+      expect(transpose([['a', 'b', 'c']])).toEqual([
+        ['a'],
+        ['b'],
+        ['c']
+      ])
+    })
+
+    it('should handle single column', () => {
+      expect(transpose([['a'], ['b'], ['c']])).toEqual([
+        ['a', 'b', 'c']
+      ])
+    })
+
+    it('should handle ragged rows by filling with empty strings', () => {
+      const data = [
+        ['a', 'b', 'c'],
+        ['d', 'e']
+      ]
+      expect(transpose(data)).toEqual([
+        ['a', 'd'],
+        ['b', 'e'],
+        ['c', '']
+      ])
+    })
+  })
+
+  describe('flipVertical', () => {
+    it('should reverse row order', () => {
+      const data = [
+        ['a', 'b'],
+        ['c', 'd'],
+        ['e', 'f']
+      ]
+      expect(flipVertical(data)).toEqual([
+        ['e', 'f'],
+        ['c', 'd'],
+        ['a', 'b']
+      ])
+    })
+
+    it('should not modify the original array', () => {
+      const data = [['a'], ['b']]
+      const result = flipVertical(data)
+      expect(data).toEqual([['a'], ['b']])
+      expect(result).toEqual([['b'], ['a']])
+    })
+
+    it('should handle empty array', () => {
+      expect(flipVertical([])).toEqual([])
+    })
+  })
+
+  describe('flipHorizontal', () => {
+    it('should reverse column order', () => {
+      const data = [
+        ['a', 'b', 'c'],
+        ['d', 'e', 'f']
+      ]
+      expect(flipHorizontal(data)).toEqual([
+        ['c', 'b', 'a'],
+        ['f', 'e', 'd']
+      ])
+    })
+
+    it('should not modify the original array', () => {
+      const data = [['a', 'b']]
+      const result = flipHorizontal(data)
+      expect(data).toEqual([['a', 'b']])
+      expect(result).toEqual([['b', 'a']])
+    })
+
+    it('should handle empty array', () => {
+      expect(flipHorizontal([])).toEqual([])
+    })
+
+    it('should handle rows with single column', () => {
+      expect(flipHorizontal([['a'], ['b']])).toEqual([['a'], ['b']])
+    })
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ const { darkMode } = storeToRefs(settingsStore)
 const tabs = [
   { id: 'fixed-length', name: '固定長相互変換' },
   { id: 'numbering-line', name: 'ナンバリング行変換' },
+  { id: 'table-transform', name: '表変換' },
   { id: 'sql-insert', name: 'SQL INSERT文生成' },
   { id: 'settings', name: '設定' }
 ]

--- a/src/components/DelimiterSelector.vue
+++ b/src/components/DelimiterSelector.vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 import type { DelimiterType } from '../utils/converter'
 
+interface Option {
+  value: DelimiterType
+  label: string
+}
+
 interface Props {
   modelValue: DelimiterType
   label?: string
+  options?: Option[]
 }
 
-const OPTIONS: { value: DelimiterType, label: string }[] = [
+const DEFAULT_OPTIONS: Option[] = [
   { value: 'auto', label: '自動判別' },
   { value: 'tsv', label: 'TSV' },
   { value: 'csv', label: 'CSV' },
@@ -23,7 +29,7 @@ defineEmits<{ (e: 'update:modelValue', value: DelimiterType): void }>()
 <template>
   <div class="delimiter-selector">
     <label v-if="label">{{ label }}</label>
-    <label v-for="opt in OPTIONS" :key="opt.value">
+    <label v-for="opt in (options || DEFAULT_OPTIONS)" :key="opt.value">
       <input
         type="radio"
         :value="opt.value"

--- a/src/components/DelimiterSelector.vue
+++ b/src/components/DelimiterSelector.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { DelimiterType } from '../utils/converter'
+
+interface Props {
+  modelValue: DelimiterType
+  label?: string
+}
+
+const OPTIONS: { value: DelimiterType, label: string }[] = [
+  { value: 'auto', label: '自動判別' },
+  { value: 'tsv', label: 'TSV' },
+  { value: 'csv', label: 'CSV' },
+  { value: 'pipe', label: 'SQL/MD' },
+  { value: 'frame', label: 'Frame表' },
+  { value: 'html', label: 'HTML' },
+  { value: 'fixed', label: '固定長' },
+]
+
+defineProps<Props>()
+defineEmits<{ (e: 'update:modelValue', value: DelimiterType): void }>()
+</script>
+
+<template>
+  <div class="delimiter-selector">
+    <label v-if="label">{{ label }}</label>
+    <label v-for="opt in OPTIONS" :key="opt.value">
+      <input
+        type="radio"
+        :value="opt.value"
+        :checked="modelValue === opt.value"
+        @change="$emit('update:modelValue', opt.value)"
+      />
+      {{ opt.label }}
+    </label>
+  </div>
+</template>

--- a/src/composables/useFileUpload.ts
+++ b/src/composables/useFileUpload.ts
@@ -1,7 +1,7 @@
 import { ref, computed } from 'vue'
 import type { Ref } from 'vue'
 
-export type DelimiterType = 'csv' | 'tsv' | 'fixed' | 'auto' | 'pipe'
+export type DelimiterType = 'csv' | 'tsv' | 'fixed' | 'auto' | 'pipe' | 'frame' | 'html'
 
 const CONTROL_CHAR_RATIO_THRESHOLD = 0.1
 const BINARY_CHECK_SIZE = 8000
@@ -90,6 +90,8 @@ export function useFileUpload(options: UseFileUploadOptions) {
         tsv: 'TSV',
         fixed: '固定長',
         pipe: 'SQL/MD表',
+        frame: 'Frame表',
+        html: 'HTML',
       }
       const typeLabel = typeLabels[detectedType]
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHashHistory } from 'vue-router'
 import FixedLengthConverter from '../views/FixedLengthConverter.vue'
 import NumberingLineConverter from '../views/NumberingLineConverter.vue'
+import TableTransformer from '../views/TableTransformer.vue'
 import SqlInsertGenerator from '../views/SqlInsertGenerator.vue'
 import SettingsPage from '../views/SettingsPage.vue'
 
@@ -20,6 +21,11 @@ const router = createRouter({
       path: '/numbering-line',
       name: 'numbering-line',
       component: NumberingLineConverter
+    },
+    {
+      path: '/table-transform',
+      name: 'table-transform',
+      component: TableTransformer
     },
     {
       path: '/sql-insert',

--- a/src/stores/tableTransform.ts
+++ b/src/stores/tableTransform.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import type { DelimiterType } from '../utils/converter'
 
-export type OutputFormat = 'csv' | 'tsv' | 'markdown' | 'html'
+export type OutputFormat = 'csv' | 'tsv' | 'markdown' | 'html' | 'frame'
 export type TransformType = 'transpose' | 'flipVertical' | 'flipHorizontal'
 
 export const useTableTransformStore = defineStore('tableTransform', () => {

--- a/src/stores/tableTransform.ts
+++ b/src/stores/tableTransform.ts
@@ -1,0 +1,27 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { DelimiterType } from '../utils/converter'
+
+export type OutputFormat = 'csv' | 'tsv' | 'markdown' | 'html'
+export type TransformType = 'transpose' | 'flipVertical' | 'flipHorizontal'
+
+export const useTableTransformStore = defineStore('tableTransform', () => {
+  const inputText = ref('')
+  const inputFormat = ref<DelimiterType>('auto')
+  const outputFormat = ref<OutputFormat>('tsv')
+  const transformTypes = ref<TransformType[]>(['transpose'])
+
+  const clearInput = () => {
+    inputText.value = ''
+  }
+
+  return {
+    inputText,
+    inputFormat,
+    outputFormat,
+    transformTypes,
+    clearInput
+  }
+}, {
+  persist: true
+})

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -1,4 +1,4 @@
-import { parseDelimitedData, parsePipe } from './delimited'
+import { parseDelimitedData, parsePipe, parseFrame } from './delimited'
 
 export interface ColumnOption {
   type: 'string' | 'number'
@@ -6,7 +6,7 @@ export interface ColumnOption {
   padChar: string
 }
 
-export type DelimiterType = 'auto' | 'tsv' | 'csv' | 'fixed' | 'pipe'
+export type DelimiterType = 'auto' | 'tsv' | 'csv' | 'pipe' | 'frame' | 'html' | 'fixed'
 
 export type OutputFormat = 'tsv' | 'csv' | 'fixed' | 'md-tbl' | 'html-tbl'
 
@@ -27,10 +27,18 @@ const normalizeUnicodeWhitespace = (value: string): string => {
     .replace(UNICODE_CONTROL_REGEX, '')  // ソフトハイフンとゼロ幅文字などの制御文字を削除
 }
 
-export const detectDelimiter = (data: string): '\t' | ',' | '|' => {
+export type DetectedDelimiter = '\t' | ',' | '|' | '│'
+
+export const detectDelimiter = (data: string): DetectedDelimiter => {
   const lines = data.split('\n').filter(line => line.trim() !== '').slice(0, 10) // 最初の10行（空行を除く）
   if (lines.length === 0) return '\t'
-  
+
+  // frame-table形式の検出（box-drawing文字のセパレータ行）
+  const hasFrameSeparator = lines.some(line => /^[\s┌─┬┐├┼┤└┴┘│]+$/.test(line))
+  if (hasFrameSeparator) {
+    return '│'
+  }
+
   // PostgreSQLパイプ形式の検出（区切り線の存在をチェック）
   const hasSeparatorLine = lines.some(line => /^[\s|+-]+$/.test(line))
   if (hasSeparatorLine) {
@@ -68,11 +76,13 @@ export const detectDelimiter = (data: string): '\t' | ',' | '|' => {
   return ','
 }
 
-export const getDelimiter = (data: string, type: DelimiterType): '\t' | ',' | '|' => {
+export const getDelimiter = (data: string, type: DelimiterType): DetectedDelimiter => {
   if (type === 'auto') return detectDelimiter(data)
   if (type === 'tsv') return '\t'
   if (type === 'csv') return ','
   if (type === 'pipe') return '|'
+  if (type === 'frame') return '│'
+  if (type === 'html') throw new Error("getDelimiter should not be called with type 'html'")
   // type === 'fixed' の場合はデリミタを検出しないため、呼び出すべきではない
   throw new Error("getDelimiter should not be called with type 'fixed'")
 }
@@ -88,7 +98,7 @@ export const getDelimiter = (data: string, type: DelimiterType): '\t' | ',' | '|
  * @returns タブまたはカンマ
  */
 export const getOptionsDelimiter = (input: string, delimiterType: DelimiterType = 'auto'): '\t' | ',' => {
-  if (delimiterType === 'auto' || delimiterType === 'fixed' || delimiterType === 'pipe') {
+  if (delimiterType === 'auto' || delimiterType === 'fixed' || delimiterType === 'pipe' || delimiterType === 'frame' || delimiterType === 'html') {
     return input.includes('\t') ? '\t' : ','
   }
   return delimiterType === 'tsv' ? '\t' : ','
@@ -253,6 +263,8 @@ export const tsvToFixedFromString = (data: string, lengths: number[], options: C
   
   if (delimiter === '|') {
     parsedData = parsePipe(data)
+  } else if (delimiter === '│') {
+    parsedData = parseFrame(data)
   } else {
     parsedData = parseDelimitedData(data, delimiter)
   }

--- a/src/utils/delimited.ts
+++ b/src/utils/delimited.ts
@@ -107,7 +107,7 @@ export function parseFrame(input: string): string[][] {
     }
 
     // box-drawing文字のみの行（セパレータ行）をスキップ
-    if (/^[\s┌─┬┐├┼┤└┴┘│]+$/.test(line)) {
+    if (/^[\s┌─┬┐├┼┤└┴┘]+$/.test(line)) {
       continue;
     }
 

--- a/src/utils/delimited.ts
+++ b/src/utils/delimited.ts
@@ -193,6 +193,42 @@ export function toPipe(data: string[][]): string {
 }
 
 /**
+ * 2次元配列をframe-table形式（Unicode box-drawing）に変換する
+ */
+export function toFrame(data: string[][]): string {
+  if (data.length === 0) return '';
+
+  const colWidths = data.reduce<number[]>((widths, row) => {
+    row.forEach((cell, i) => {
+      const cellLen = (cell || '').length;
+      widths[i] = Math.max(widths[i] || 1, cellLen);
+    });
+    return widths;
+  }, []);
+
+  const topBorder = '┌' + colWidths.map(w => '─'.repeat(w)).join('┬') + '┐';
+  const midBorder = '├' + colWidths.map(w => '─'.repeat(w)).join('┼') + '┤';
+  const bottomBorder = '└' + colWidths.map(w => '─'.repeat(w)).join('┴') + '┘';
+
+  const lines: string[] = [topBorder];
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    const row = data[rowIndex];
+    const paddedCols = row.map((col, i) => {
+      const width = colWidths[i] || 1;
+      return (col || '').padEnd(width, ' ');
+    });
+    lines.push('│' + paddedCols.join('│') + '│');
+
+    if (rowIndex === 0 && data.length > 1) {
+      lines.push(midBorder);
+    }
+  }
+  lines.push(bottomBorder);
+
+  return lines.join('\n');
+}
+
+/**
  * 2次元配列をMarkdown表形式に変換する
  */
 export function toMarkdown(data: string[][]): string {

--- a/src/utils/delimited.ts
+++ b/src/utils/delimited.ts
@@ -89,6 +89,49 @@ export function parsePipe(input: string): string[][] {
 }
 
 /**
+ * Unicode box-drawing文字のframe-tableをパースする
+ * 例:
+ * ┌───────────────┬────────┬────────────┐
+ * │  Model / Bot  │ AvgPen │ Normalized │
+ * ├───────────────┼────────┼────────────┤
+ * │ pmc:100:1.0   │ 6.38   │ 2.16       │
+ * └───────────────┴────────┴────────────┘
+ */
+export function parseFrame(input: string): string[][] {
+  const lines = input.split('\n');
+  const result: string[][] = [];
+
+  for (const line of lines) {
+    if (line.trim() === '') {
+      continue;
+    }
+
+    // box-drawing文字のみの行（セパレータ行）をスキップ
+    if (/^[\s┌─┬┐├┼┤└┴┘│]+$/.test(line)) {
+      continue;
+    }
+
+    let trimmedLine = line.trim();
+
+    // 行頭・行末の │ (U+2502) を削除
+    if (trimmedLine.startsWith('│')) {
+      trimmedLine = trimmedLine.slice(1);
+    }
+    if (trimmedLine.endsWith('│')) {
+      trimmedLine = trimmedLine.slice(0, -1);
+    }
+
+    const columns = trimmedLine.split('│').map(col => col.trim());
+
+    if (columns.length > 0) {
+      result.push(columns);
+    }
+  }
+
+  return result;
+}
+
+/**
  * 2次元配列を区切り文字列に変換する（共通関数）
  */
 function unparseDelimited(data: string[][], delimiter: ',' | '\t', forceAllString = false): string {
@@ -217,6 +260,43 @@ export function toHtmlTable(data: string[][]): string {
 
   lines.push('</table>');
   return lines.join('\n');
+}
+
+/**
+ * HTML表形式をパースする
+ */
+export function parseHtmlTable(input: string): string[][] {
+  const result: string[][] = []
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi
+  const cellRegex = /<t[dh][^>]*>([\s\S]*?)<\/t[dh]>/gi
+
+  const htmlDecode = (text: string): string => {
+    return text
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .trim()
+  }
+
+  let rowMatch: RegExpExecArray | null
+  while ((rowMatch = rowRegex.exec(input)) !== null) {
+    const rowContent = rowMatch[1]
+    const cells: string[] = []
+    let cellMatch: RegExpExecArray | null
+    cellRegex.lastIndex = 0
+    while ((cellMatch = cellRegex.exec(rowContent)) !== null) {
+      cells.push(htmlDecode(cellMatch[1]))
+    }
+    if (cells.length > 0) {
+      result.push(cells)
+    }
+  }
+
+  return result
 }
 
 /**

--- a/src/utils/tableTransform.ts
+++ b/src/utils/tableTransform.ts
@@ -1,0 +1,34 @@
+/**
+ * 2次元配列の縦横変換（転置）
+ * 行数が異なる場合は空文字で埋める
+ */
+export function transpose(data: string[][]): string[][] {
+  if (data.length === 0) return []
+
+  const maxCols = Math.max(...data.map(row => row.length))
+  const result: string[][] = []
+
+  for (let col = 0; col < maxCols; col++) {
+    const newRow: string[] = []
+    for (let row = 0; row < data.length; row++) {
+      newRow.push(data[row][col] ?? '')
+    }
+    result.push(newRow)
+  }
+
+  return result
+}
+
+/**
+ * 2次元配列の上下反転（行の順序を逆転）
+ */
+export function flipVertical(data: string[][]): string[][] {
+  return [...data].reverse()
+}
+
+/**
+ * 2次元配列の左右反転（列の順序を逆転）
+ */
+export function flipHorizontal(data: string[][]): string[][] {
+  return data.map(row => [...row].reverse())
+}

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -3,8 +3,9 @@ import { ref, computed, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConverterStore } from '../stores/converter'
 import { parseColumnLengths, parseColumnOptions, getDelimiter, parseFixed, tsvToFixed as convertTsvToFixed } from '../utils/converter'
-import { parseDelimitedData, parsePipe, toCSV, toTSV, toMarkdown, toHtmlTable } from '../utils/delimited'
+import { parseDelimitedData, parsePipe, parseFrame, toCSV, toTSV, toMarkdown, toHtmlTable } from '../utils/delimited'
 import { useNotification } from '../composables/useNotification'
+import DelimiterSelector from '../components/DelimiterSelector.vue'
 import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
 import { useFileUpload } from '../composables/useFileUpload'
 import { usePresetCache } from '../composables/usePresetCache'
@@ -129,6 +130,8 @@ const isDelimitedData = (data: string, expectedColumnCount: number): ParseResult
 
     if (delimiter === '|') {
       allRows = parsePipe(trimmedData)
+    } else if (delimiter === '│') {
+      allRows = parseFrame(trimmedData)
     } else {
       allRows = parseDelimitedData(trimmedData, delimiter)
     }
@@ -172,7 +175,7 @@ const resultPlaceholder = computed(() => {
 
 const handleDelimitedInput = (lengths: number[], parsedData: string[][], data: string) => {
   const delimiter = getDelimiter(data, delimiterType.value)
-  const inputType = delimiter === '\t' ? 'TSV' : delimiter === '|' ? 'SQL/MD表' : 'CSV'
+  const inputType = delimiter === '\t' ? 'TSV' : delimiter === '|' ? 'SQL/MD表' : delimiter === '│' ? 'Frame表' : 'CSV'
 
   // useFirstRowAsHeaderがtrueの場合、1行目をスキップ
   let dataRows = parsedData
@@ -216,7 +219,9 @@ const handleFixedWidthInput = (lengths: number[], data: string) => {
     const headerDelimiter = getDelimiter(columnHeaders.value, 'auto')
     const headers = headerDelimiter === '|'
       ? parsePipe(columnHeaders.value)[0]
-      : parseDelimitedData(columnHeaders.value, headerDelimiter)[0]
+      : headerDelimiter === '│'
+        ? parseFrame(columnHeaders.value)[0]
+        : parseDelimitedData(columnHeaders.value, headerDelimiter)[0]
     processedData = [headers, ...processedData]
   }
 
@@ -351,6 +356,10 @@ const clearDataBody = () => {
   <div class="converter-container">
     <div class="header-row">
       <h2>固定長相互変換</h2>
+      <DelimiterSelector
+        v-model="delimiterType"
+        label="入力形式:"
+      />
     </div>
 
     <div class="preset-section">

--- a/src/views/NumberingLineConverter.vue
+++ b/src/views/NumberingLineConverter.vue
@@ -5,6 +5,7 @@ import { convertNumberingLines } from '../utils/numberingConverter'
 import { parseCSV, parseTSV, toCSV, toTSV } from '../utils/delimited'
 import { getDelimiter } from '../utils/converter'
 import { useNumberingStore } from '../stores/numbering'
+import DelimiterSelector from '../components/DelimiterSelector.vue'
 
 const store = useNumberingStore()
 const { 
@@ -130,21 +131,15 @@ const { clearDataBody, togglePattern } = store
   <div class="converter-container">
     <div class="header-row">
       <h2>ナンバリング行変換</h2>
-      <div class="delimiter-selector">
-        <label>入力形式:</label>
-        <label>
-          <input type="radio" value="auto" v-model="inputDelimiterType" />
-          自動判別
-        </label>
-        <label>
-          <input type="radio" value="tsv" v-model="inputDelimiterType" />
-          TSV
-        </label>
-        <label>
-          <input type="radio" value="csv" v-model="inputDelimiterType" />
-          CSV
-        </label>
-      </div>
+      <DelimiterSelector
+        v-model="inputDelimiterType"
+        label="入力形式:"
+        :options="[
+          { value: 'auto', label: '自動判別' },
+          { value: 'tsv', label: 'TSV' },
+          { value: 'csv', label: 'CSV' },
+        ]"
+      />
     </div>
 
     <div class="input-section">

--- a/src/views/SqlInsertGenerator.vue
+++ b/src/views/SqlInsertGenerator.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useSqlInsertStore } from '../stores/sqlInsert'
 import { getDelimiter, parseColumnLengths, convertFromFixed } from '../utils/converter'
-import { parseDelimitedData, parsePipe } from '../utils/delimited'
+import { parseDelimitedData, parsePipe, parseFrame } from '../utils/delimited'
 import { generateInsertStatements, parseColumnOptions } from '../utils/sqlInsert'
 import NotificationToast from '../components/NotificationToast.vue'
+import DelimiterSelector from '../components/DelimiterSelector.vue'
 import { useFileUpload } from '../composables/useFileUpload'
 import { useNotification } from '../composables/useNotification'
 import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
 
 const DEFAULT_TABLE_NAME = 'YOUR_TABLE_NAME'
+const AUTO_REGEN_LIMIT = 100000
 
 const store = useSqlInsertStore()
 const { tableName, dataBody, columnHeaders, columnOptions, useFirstRowAsHeader, delimiterType, columnLengths, insertFormat, useBacktick, forceAllString } = storeToRefs(store)
@@ -44,6 +46,16 @@ const {
 const fileInputRef = fileInput
 void fileInputRef // テンプレートで使用されるが、スクリプト内では未使用
 
+// パース済みデータ（INSERT形式切替時の再生成用）
+interface ParsedState {
+  columns: string[]
+  dataRows: string[][]
+  columnTypes: ReturnType<typeof parseColumnOptions> | undefined
+  finalTableName: string
+  inputType: string
+}
+const parsedState = ref<ParsedState | null>(null)
+
 const copyFieldToClipboard = (text: string, fieldName: string) => {
   navigator.clipboard.writeText(text).then(() => {
     showNotification(`${fieldName}をコピーしました`)
@@ -61,10 +73,15 @@ const parseInputData = (data: string): string[][] | false => {
   if (delimiterType.value === 'fixed') {
     const lengths = parseColumnLengths(columnLengths.value, delimiterType.value)
     if (lengths.length === 0) return false
-    
+
     // 固定長→TSVに変換してからパース
     const tsvData = convertFromFixed(trimmedData, lengths, 'tsv')
     return parseDelimitedData(tsvData, '\t')
+  }
+
+  // frame-tableとして明示的に指定されている場合
+  if (delimiterType.value === 'frame') {
+    return parseFrame(trimmedData)
   }
 
   // TSV/CSV/SQL表としてパース
@@ -73,10 +90,39 @@ const parseInputData = (data: string): string[][] | false => {
     if (delimiter === '|') {
       return parsePipe(trimmedData)
     }
+    if (delimiter === '│') {
+      return parseFrame(trimmedData)
+    }
     return parseDelimitedData(trimmedData, delimiter)
   } catch {
     return false
   }
+}
+
+const buildInputType = (data: string): string => {
+  const delimiter = delimiterType.value === 'fixed' ? null : getDelimiter(data, delimiterType.value)
+  return delimiterType.value === 'fixed' ? '固定長' :
+         delimiterType.value === 'frame' ? 'Frame表' :
+         delimiter === '\t' ? 'TSV' :
+         delimiter === '|' ? 'SQL/MD表' :
+         delimiter === '│' ? 'Frame表' : 'CSV'
+}
+
+const generateFromState = () => {
+  if (!parsedState.value) return
+  const { columns, dataRows, columnTypes, finalTableName, inputType } = parsedState.value
+  const outputType = insertFormat.value === 'single' ? '単一行INSERT' : '複数行INSERT'
+  conversionType.value = `${inputType} → SQL INSERT (${outputType})`
+
+  fullResult.value = generateInsertStatements(
+    finalTableName,
+    columns,
+    dataRows,
+    insertFormat.value,
+    columnTypes,
+    useBacktick.value,
+    forceAllString.value
+  )
 }
 
 const convert = async () => {
@@ -107,7 +153,6 @@ const convert = async () => {
       // 1行目をヘッダーとして使用
       columns = parsedData[0]
       dataRows = parsedData.slice(1)
-      conversionType.value = '1行目をヘッダーとして使用'
     } else {
       // 別途入力されたヘッダーを使用
       if (!columnHeaders.value.trim()) {
@@ -117,12 +162,13 @@ const convert = async () => {
       let headerData: string[][]
       if (delimiter === '|') {
         headerData = parsePipe(columnHeaders.value)
+      } else if (delimiter === '│') {
+        headerData = parseFrame(columnHeaders.value)
       } else {
         headerData = parseDelimitedData(columnHeaders.value, delimiter)
       }
       columns = headerData[0]
       dataRows = parsedData
-      conversionType.value = '別途入力したヘッダーを使用'
     }
 
     if (dataRows.length === 0) {
@@ -130,40 +176,34 @@ const convert = async () => {
     }
 
     // カラムオプションのパース
-    const columnTypes = columnOptions.value.trim() 
-      ? parseColumnOptions(columnOptions.value, delimiterType.value) 
+    const columnTypes = columnOptions.value.trim()
+      ? parseColumnOptions(columnOptions.value, delimiterType.value)
       : undefined
 
     // テーブル名（空の場合はデフォルト値）
     const finalTableName = tableName.value.trim() || DEFAULT_TABLE_NAME
+    const inputType = buildInputType(data)
 
-    // INSERT文生成
-    const delimiter = delimiterType.value === 'fixed' ? null : getDelimiter(data, delimiterType.value)
-    const inputType = delimiterType.value === 'fixed' ? '固定長' :
-                     delimiter === '\t' ? 'TSV' : 
-                     delimiter === '|' ? 'SQL/MD表' : 'CSV'
-    const outputType = insertFormat.value === 'single' ? '単一行INSERT' : '複数行INSERT'
-    conversionType.value = `${inputType} → SQL INSERT (${outputType})`
+    // パース済み状態を保存
+    parsedState.value = { columns, dataRows, columnTypes, finalTableName, inputType }
 
-    const generatedResult = generateInsertStatements(
-      finalTableName,
-      columns,
-      dataRows,
-      insertFormat.value,
-      columnTypes,
-      useBacktick.value,
-      forceAllString.value
-    )
-
-    // Store full result
-    fullResult.value = generatedResult
+    generateFromState()
   } catch (error) {
     fullResult.value = 'エラー: ' + (error as Error).message
     conversionType.value = ''
+    parsedState.value = null
   } finally {
     convertLoading.value = false
   }
 }
+
+// INSERT形式切替時に自動再生成（データ量が大きくない場合）
+watch(insertFormat, () => {
+  if (!parsedState.value) return
+  if (fullResult.value.length <= AUTO_REGEN_LIMIT) {
+    generateFromState()
+  }
+})
 
 const copyToClipboard = () => {
   copyLoading.value = true
@@ -226,50 +266,32 @@ const resultPlaceholder = computed(() => {
   <div class="converter-container">
     <div class="header-row">
       <h2>SQL INSERT文生成</h2>
-      <div class="delimiter-selector">
-        <label>
-          <input type="radio" value="auto" v-model="delimiterType" />
-          自動判別
-        </label>
-        <label>
-          <input type="radio" value="tsv" v-model="delimiterType" />
-          TSV
-        </label>
-        <label>
-          <input type="radio" value="csv" v-model="delimiterType" />
-          CSV
-        </label>
-        <label>
-          <input type="radio" value="pipe" v-model="delimiterType" />
-          SQL/MD表
-        </label>
-        <label>
-          <input type="radio" value="fixed" v-model="delimiterType" />
-          固定長
-        </label>
-      </div>
+      <DelimiterSelector
+        v-model="delimiterType"
+        label="入力形式:"
+      />
     </div>
 
     <div class="input-section input-section-inline">
       <div class="input-header">
         <div class="input-actions">
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="copyFieldToClipboard(tableName, 'テーブル名')"
             :disabled="!tableName"
             title="コピー"
           >
             <i class="mdi mdi-content-copy"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="pasteFromClipboard('tableName')"
             title="ペーストして置換"
           >
             <i class="mdi mdi-content-paste"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="store.clearTableName()"
             :disabled="!tableName"
             title="クリア"
@@ -279,7 +301,7 @@ const resultPlaceholder = computed(() => {
         </div>
         <h3>テーブル名<span class="optional">（省略可）</span></h3>
       </div>
-      <input 
+      <input
         type="text"
         v-model="tableName"
         :placeholder="DEFAULT_TABLE_NAME"
@@ -290,24 +312,24 @@ const resultPlaceholder = computed(() => {
     <div class="input-section">
       <div class="input-header">
         <div class="input-actions">
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="copyFieldToClipboard(columnLengths, 'カラム長')"
             :disabled="!columnLengths || delimiterType !== 'fixed'"
             title="コピー"
           >
             <i class="mdi mdi-content-copy"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="pasteFromClipboard('columnLengths')"
             :disabled="delimiterType !== 'fixed'"
             title="ペーストして置換"
           >
             <i class="mdi mdi-content-paste"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="store.clearColumnLengths()"
             :disabled="!columnLengths || delimiterType !== 'fixed'"
             title="クリア"
@@ -317,10 +339,10 @@ const resultPlaceholder = computed(() => {
         </div>
         <h3>カラム長<span class="optional">（固定長の場合のみ）</span></h3>
       </div>
-      <textarea 
+      <textarea
         v-model="columnLengths"
         :disabled="delimiterType !== 'fixed'"
-        rows="2" 
+        rows="2"
         placeholder="10,20,15&#10;(CSV or TSV形式)"
       ></textarea>
     </div>
@@ -390,24 +412,24 @@ const resultPlaceholder = computed(() => {
     <div class="input-section">
       <div class="input-header">
         <div class="input-actions">
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="copyFieldToClipboard(columnHeaders, 'カラムヘッダー')"
             :disabled="!columnHeaders || useFirstRowAsHeader"
             title="コピー"
           >
             <i class="mdi mdi-content-copy"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="pasteFromClipboard('columnHeaders')"
             :disabled="useFirstRowAsHeader"
             title="ペーストして置換"
           >
             <i class="mdi mdi-content-paste"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="store.clearColumnHeaders()"
             :disabled="!columnHeaders || useFirstRowAsHeader"
             title="クリア"
@@ -417,10 +439,10 @@ const resultPlaceholder = computed(() => {
         </div>
         <h3>カラムヘッダー</h3>
       </div>
-      <textarea 
+      <textarea
         v-model="columnHeaders"
         :disabled="useFirstRowAsHeader"
-        rows="2" 
+        rows="2"
         placeholder="id,name,age&#10;(CSV or TSV形式)"
       ></textarea>
     </div>
@@ -428,23 +450,23 @@ const resultPlaceholder = computed(() => {
     <div class="input-section">
       <div class="input-header">
         <div class="input-actions">
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="copyFieldToClipboard(columnOptions, 'カラムオプション')"
             :disabled="!columnOptions"
             title="コピー"
           >
             <i class="mdi mdi-content-copy"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="pasteFromClipboard('columnOptions')"
             title="ペーストして置換"
           >
             <i class="mdi mdi-content-paste"></i>
           </button>
-          <button 
-            class="btn btn-icon-small" 
+          <button
+            class="btn btn-icon-small"
             @click="store.clearColumnOptions()"
             :disabled="!columnOptions"
             title="クリア"
@@ -474,8 +496,8 @@ const resultPlaceholder = computed(() => {
     </div>
 
     <div class="button-group">
-      <button 
-        class="btn btn-primary" 
+      <button
+        class="btn btn-primary"
         @click="convert"
         :disabled="convertLoading"
         :class="{ loading: convertLoading }"
@@ -509,9 +531,9 @@ const resultPlaceholder = computed(() => {
         </div>
         <h3>実行結果<span v-if="conversionType" class="conversion-type">（{{ conversionType }}）</span></h3>
       </div>
-      <textarea :value="displayResult" rows="10" readonly :placeholder="resultPlaceholder"></textarea>
-      <div class="result-actions">
-        <div class="output-format-selector">
+      <div class="result-textarea-wrapper">
+        <textarea :value="displayResult" rows="10" readonly :placeholder="resultPlaceholder"></textarea>
+        <div class="result-textarea-overlay">
           <label>INSERT形式:</label>
           <label>
             <input type="radio" value="single" v-model="insertFormat" />
@@ -525,10 +547,66 @@ const resultPlaceholder = computed(() => {
       </div>
     </div>
 
-    <NotificationToast 
+    <NotificationToast
       :show="showNotificationFlag"
       :message="notificationMessage"
       :type="notificationType"
     />
   </div>
 </template>
+
+<style scoped>
+.result-textarea-wrapper {
+  position: relative;
+}
+
+.result-textarea-wrapper textarea {
+  width: 100%;
+  min-height: 200px;
+  padding: 10px;
+  padding-bottom: 35px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 14px;
+  resize: vertical;
+  background-color: var(--result-bg);
+  color: var(--text-primary);
+  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.3s ease;
+  box-sizing: border-box;
+}
+
+.result-textarea-overlay {
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 3px 10px;
+  background-color: var(--bg-tertiary);
+  border-radius: 4px;
+  border: 1px solid var(--border-color-light);
+  font-size: 12px;
+  color: var(--btn-icon-text);
+  transition: background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.result-textarea-overlay label {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+}
+
+.result-textarea-overlay label:first-child {
+  font-weight: 500;
+  cursor: default;
+}
+
+.result-textarea-overlay input[type="radio"] {
+  cursor: pointer;
+  margin-right: 2px;
+  accent-color: #667eea;
+}
+</style>

--- a/src/views/TableTransformer.vue
+++ b/src/views/TableTransformer.vue
@@ -2,7 +2,7 @@
 import { ref, computed, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { transpose, flipVertical, flipHorizontal } from '../utils/tableTransform'
-import { parseCSV, parseTSV, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toMarkdown, toHtmlTable } from '../utils/delimited'
+import { parseCSV, parseTSV, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
 import { detectDelimiter } from '../utils/converter'
 import { useTableTransformStore } from '../stores/tableTransform'
 import { useNotification } from '../composables/useNotification'
@@ -68,6 +68,7 @@ const formatOutput = (data: string[][], format: OutputFormat): string => {
   if (format === 'tsv') return toTSV(data)
   if (format === 'markdown') return toMarkdown(data)
   if (format === 'html') return toHtmlTable(data)
+  if (format === 'frame') return toFrame(data)
   return toTSV(data)
 }
 
@@ -90,6 +91,7 @@ const resultPlaceholder = computed(() => {
   if (outputFormat.value === 'csv') return 'name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\n(変換結果がここに表示されます)'
   if (outputFormat.value === 'markdown') return '| name | age | city |\n| ---- | --- | ---- |\n| Alice | 30 | Tokyo |\n| Bob | 25 | Osaka |\n(変換結果がここに表示されます)'
   if (outputFormat.value === 'html') return '<table>\n  <tr>\n    <th>name</th>\n    <th>age</th>\n    <th>city</th>\n  </tr>\n  ...\n</table>\n(変換結果がここに表示されます)'
+  if (outputFormat.value === 'frame') return '┌──────┬─────┬───────┐\n│ name │ age │ city  │\n├──────┼─────┼───────┤\n│Alice │ 30  │ Tokyo │\n│ Bob  │ 25  │ Osaka │\n└──────┴─────┴───────┘\n(変換結果がここに表示されます)'
   return 'name\tage\tcity\nAlice\t30\tTokyo\nBob\t25\tOsaka\n(変換結果がここに表示されます)'
 })
 
@@ -123,7 +125,7 @@ const convert = async () => {
     const inputType = inputFormat.value === 'auto'
       ? (detected === '\t' ? 'TSV' : detected === ',' ? 'CSV' : detected === '|' ? 'SQL/MD表' : detected === '│' ? 'Frame表' : 'TSV')
       : inputFormat.value === 'pipe' ? 'SQL/MD' : inputFormat.value === 'frame' ? 'Frame表' : inputFormat.value.toUpperCase()
-    const outputType = outputFormat.value === 'markdown' ? 'Markdown' : outputFormat.value.toUpperCase()
+    const outputType = outputFormat.value === 'markdown' ? 'Markdown' : outputFormat.value === 'frame' ? 'Frame表' : outputFormat.value.toUpperCase()
     const typeLabels = transformTypes.value.map(t => transformLabels[t]).join('+')
     conversionType.value = `${typeLabels} (${inputType} → ${outputType})`
   } catch (error) {
@@ -147,7 +149,7 @@ const copyToClipboard = () => {
 
 const downloadResult = () => {
   downloadLoading.value = true
-  const extMap: Record<OutputFormat, string> = { csv: '.csv', tsv: '.tsv', markdown: '.md', html: '.html' }
+  const extMap: Record<OutputFormat, string> = { csv: '.csv', tsv: '.tsv', markdown: '.md', html: '.html', frame: '.txt' }
   const blob = new Blob([fullResult.value], { type: 'text/plain' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
@@ -281,6 +283,10 @@ const clearInputData = () => {
           <label class="format-option">
             <input type="radio" value="html" v-model="outputFormat" />
             HTML
+          </label>
+          <label class="format-option">
+            <input type="radio" value="frame" v-model="outputFormat" />
+            Frame表
           </label>
         </div>
       </div>

--- a/src/views/TableTransformer.vue
+++ b/src/views/TableTransformer.vue
@@ -119,8 +119,9 @@ const convert = async () => {
     const transformed = transformAll(parsed, transformTypes.value)
     fullResult.value = formatOutput(transformed, outputFormat.value)
 
+    const detected = detectDelimiter(data)
     const inputType = inputFormat.value === 'auto'
-      ? (detectDelimiter(data) === '\t' ? 'TSV' : detectDelimiter(data) === ',' ? 'CSV' : detectDelimiter(data) === '|' ? 'SQL/MD表' : 'TSV')
+      ? (detected === '\t' ? 'TSV' : detected === ',' ? 'CSV' : detected === '|' ? 'SQL/MD表' : detected === '│' ? 'Frame表' : 'TSV')
       : inputFormat.value === 'pipe' ? 'SQL/MD' : inputFormat.value === 'frame' ? 'Frame表' : inputFormat.value.toUpperCase()
     const outputType = outputFormat.value === 'markdown' ? 'Markdown' : outputFormat.value.toUpperCase()
     const typeLabels = transformTypes.value.map(t => transformLabels[t]).join('+')
@@ -263,32 +264,6 @@ const clearInputData = () => {
       </button>
 
       <div class="format-selectors">
-        <div class="format-group">
-          <span class="format-label">入力:</span>
-          <label class="format-option">
-            <input type="radio" value="auto" v-model="inputFormat" />
-            自動
-          </label>
-          <label class="format-option">
-            <input type="radio" value="tsv" v-model="inputFormat" />
-            TSV
-          </label>
-          <label class="format-option">
-            <input type="radio" value="csv" v-model="inputFormat" />
-            CSV
-          </label>
-          <label class="format-option">
-            <input type="radio" value="markdown" v-model="inputFormat" />
-            MD
-          </label>
-          <label class="format-option">
-            <input type="radio" value="html" v-model="inputFormat" />
-            HTML
-          </label>
-        </div>
-
-        <span class="format-arrow"><i class="mdi mdi-arrow-right"></i></span>
-
         <div class="format-group">
           <span class="format-label">出力:</span>
           <label class="format-option">

--- a/src/views/TableTransformer.vue
+++ b/src/views/TableTransformer.vue
@@ -1,0 +1,363 @@
+<script setup lang="ts">
+import { ref, computed, toRef } from 'vue'
+import { storeToRefs } from 'pinia'
+import { transpose, flipVertical, flipHorizontal } from '../utils/tableTransform'
+import { parseCSV, parseTSV, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toMarkdown, toHtmlTable } from '../utils/delimited'
+import { detectDelimiter } from '../utils/converter'
+import { useTableTransformStore } from '../stores/tableTransform'
+import { useNotification } from '../composables/useNotification'
+import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
+import { useFileUpload } from '../composables/useFileUpload'
+import NotificationToast from '../components/NotificationToast.vue'
+import DelimiterSelector from '../components/DelimiterSelector.vue'
+import type { OutputFormat, TransformType } from '../stores/tableTransform'
+import type { DelimiterType } from '../utils/converter'
+
+const store = useTableTransformStore()
+const { inputText, inputFormat, outputFormat, transformTypes } = storeToRefs(store)
+
+const fullResult = ref('')
+const conversionType = ref('')
+const convertLoading = ref(false)
+const copyLoading = ref(false)
+const downloadLoading = ref(false)
+
+const { notificationMessage, notificationType, showNotificationFlag, showNotification } = useNotification()
+const { displayResult } = useTruncatedDisplay(fullResult)
+
+const {
+  fileInputRef: fileInput,
+  uploadedFile,
+  displayDataBody,
+  uploadFile,
+  handleFileUpload,
+  clearUploadedFile,
+} = useFileUpload({
+  dataBody: toRef(store, 'inputText'),
+  delimiterType: toRef(store, 'inputFormat') as any,
+  onSuccess: showNotification,
+  onError: (message) => showNotification(message, 'error'),
+})
+
+const fileInputRef = fileInput
+void fileInputRef
+
+const hasInputText = computed(() => !!(uploadedFile.value || inputText.value))
+
+const parseInput = (text: string, format: DelimiterType): string[][] => {
+  if (format === 'html') return parseHtmlTable(text)
+
+  if (format === 'auto') {
+    const delimiter = detectDelimiter(text)
+    if (delimiter === '\t') return parseTSV(text)
+    if (delimiter === ',') return parseCSV(text)
+    if (delimiter === '|') return parsePipe(text)
+    if (delimiter === '│') return parseFrame(text)
+    return parseTSV(text)
+  }
+
+  if (format === 'tsv') return parseTSV(text)
+  if (format === 'csv') return parseCSV(text)
+  if (format === 'pipe') return parsePipe(text)
+  if (format === 'frame') return parseFrame(text)
+  return parseTSV(text)
+}
+
+const formatOutput = (data: string[][], format: OutputFormat): string => {
+  if (format === 'csv') return toCSV(data)
+  if (format === 'tsv') return toTSV(data)
+  if (format === 'markdown') return toMarkdown(data)
+  if (format === 'html') return toHtmlTable(data)
+  return toTSV(data)
+}
+
+const transformLabels: Record<TransformType, string> = {
+  transpose: '縦横変換（転置）',
+  flipVertical: '上下反転',
+  flipHorizontal: '左右反転'
+}
+
+const transformAll = (data: string[][], types: TransformType[]): string[][] => {
+  return types.reduce((acc, type) => {
+    if (type === 'transpose') return transpose(acc)
+    if (type === 'flipVertical') return flipVertical(acc)
+    if (type === 'flipHorizontal') return flipHorizontal(acc)
+    return acc
+  }, data)
+}
+
+const resultPlaceholder = computed(() => {
+  if (outputFormat.value === 'csv') return 'name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\n(変換結果がここに表示されます)'
+  if (outputFormat.value === 'markdown') return '| name | age | city |\n| ---- | --- | ---- |\n| Alice | 30 | Tokyo |\n| Bob | 25 | Osaka |\n(変換結果がここに表示されます)'
+  if (outputFormat.value === 'html') return '<table>\n  <tr>\n    <th>name</th>\n    <th>age</th>\n    <th>city</th>\n  </tr>\n  ...\n</table>\n(変換結果がここに表示されます)'
+  return 'name\tage\tcity\nAlice\t30\tTokyo\nBob\t25\tOsaka\n(変換結果がここに表示されます)'
+})
+
+const convert = async () => {
+  convertLoading.value = true
+  try {
+    let data: string
+    if (uploadedFile.value) {
+      data = await uploadedFile.value.text()
+    } else {
+      data = inputText.value
+    }
+
+    if (!data.trim()) {
+      throw new Error('入力データを入力してください')
+    }
+
+    const parsed = parseInput(data, inputFormat.value)
+    if (parsed.length === 0) {
+      throw new Error('有効なデータが見つかりません')
+    }
+
+    if (transformTypes.value.length === 0) {
+      throw new Error('変換形式を1つ以上選択してください')
+    }
+
+    const transformed = transformAll(parsed, transformTypes.value)
+    fullResult.value = formatOutput(transformed, outputFormat.value)
+
+    const inputType = inputFormat.value === 'auto'
+      ? (detectDelimiter(data) === '\t' ? 'TSV' : detectDelimiter(data) === ',' ? 'CSV' : detectDelimiter(data) === '|' ? 'SQL/MD表' : 'TSV')
+      : inputFormat.value === 'pipe' ? 'SQL/MD' : inputFormat.value === 'frame' ? 'Frame表' : inputFormat.value.toUpperCase()
+    const outputType = outputFormat.value === 'markdown' ? 'Markdown' : outputFormat.value.toUpperCase()
+    const typeLabels = transformTypes.value.map(t => transformLabels[t]).join('+')
+    conversionType.value = `${typeLabels} (${inputType} → ${outputType})`
+  } catch (error) {
+    fullResult.value = 'エラー: ' + (error as Error).message
+    conversionType.value = ''
+  } finally {
+    convertLoading.value = false
+  }
+}
+
+const copyToClipboard = () => {
+  copyLoading.value = true
+  navigator.clipboard.writeText(fullResult.value).then(() => {
+    copyLoading.value = false
+    showNotification('コピーしました（完全なデータ）')
+  }).catch(() => {
+    copyLoading.value = false
+    showNotification('コピーに失敗しました', 'error')
+  })
+}
+
+const downloadResult = () => {
+  downloadLoading.value = true
+  const extMap: Record<OutputFormat, string> = { csv: '.csv', tsv: '.tsv', markdown: '.md', html: '.html' }
+  const blob = new Blob([fullResult.value], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'result' + extMap[outputFormat.value]
+  a.click()
+  URL.revokeObjectURL(url)
+  setTimeout(() => {
+    downloadLoading.value = false
+    showNotification('ダウンロードしました（完全なデータ）')
+  }, 300)
+}
+
+const copyFieldToClipboard = (text: string, fieldName: string) => {
+  navigator.clipboard.writeText(text).then(() => {
+    showNotification(`${fieldName}をコピーしました`)
+  }).catch(() => {
+    showNotification('コピーに失敗しました', 'error')
+  })
+}
+
+const pasteFromClipboard = async () => {
+  try {
+    const text = await navigator.clipboard.readText()
+    clearUploadedFile()
+    inputText.value = text
+    showNotification('ペーストしました')
+  } catch {
+    showNotification('ペーストに失敗しました', 'error')
+  }
+}
+
+const clearInputData = () => {
+  clearUploadedFile()
+  store.clearInput()
+}
+</script>
+
+<template>
+  <div class="converter-container">
+    <div class="header-row">
+      <h2>表変換</h2>
+      <DelimiterSelector
+        v-model="inputFormat"
+        label="入力形式:"
+      />
+    </div>
+
+    <div class="input-section">
+      <input
+        type="file"
+        ref="fileInputRef"
+        @change="handleFileUpload"
+        style="display: none"
+      />
+      <div class="input-header">
+        <div class="input-actions">
+          <button
+            class="btn btn-icon-small"
+            @click="uploadFile"
+            title="ファイルから読み込み"
+          >
+            <i class="mdi mdi-file-upload"></i>
+          </button>
+          <button
+            class="btn btn-icon-small"
+            @click="copyFieldToClipboard(displayDataBody, '入力データ')"
+            :disabled="!hasInputText"
+            title="コピー"
+          >
+            <i class="mdi mdi-content-copy"></i>
+          </button>
+          <button
+            class="btn btn-icon-small"
+            @click="pasteFromClipboard"
+            title="ペーストして置換"
+          >
+            <i class="mdi mdi-content-paste"></i>
+          </button>
+          <button
+            class="btn btn-icon-small"
+            @click="clearInputData"
+            :disabled="!hasInputText"
+            title="クリア"
+          >
+            <i class="mdi mdi-delete"></i>
+          </button>
+        </div>
+        <h3>入力データ</h3>
+      </div>
+      <textarea
+        v-if="!uploadedFile"
+        v-model="inputText"
+        rows="8"
+        placeholder="name,age,city&#10;Alice,30,Tokyo&#10;Bob,25,Osaka&#10;(CSV/TSV/Markdown/HTML表形式)"
+      ></textarea>
+      <textarea
+        v-else
+        :value="displayDataBody"
+        readonly
+        rows="8"
+      ></textarea>
+    </div>
+
+    <div class="conversion-row">
+      <button
+        class="btn btn-primary"
+        @click="convert"
+        :disabled="convertLoading"
+        :class="{ loading: convertLoading }"
+      >
+        <i class="mdi mdi-auto-fix"></i>
+        <span>変換</span>
+      </button>
+
+      <div class="format-selectors">
+        <div class="format-group">
+          <span class="format-label">入力:</span>
+          <label class="format-option">
+            <input type="radio" value="auto" v-model="inputFormat" />
+            自動
+          </label>
+          <label class="format-option">
+            <input type="radio" value="tsv" v-model="inputFormat" />
+            TSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="csv" v-model="inputFormat" />
+            CSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="markdown" v-model="inputFormat" />
+            MD
+          </label>
+          <label class="format-option">
+            <input type="radio" value="html" v-model="inputFormat" />
+            HTML
+          </label>
+        </div>
+
+        <span class="format-arrow"><i class="mdi mdi-arrow-right"></i></span>
+
+        <div class="format-group">
+          <span class="format-label">出力:</span>
+          <label class="format-option">
+            <input type="radio" value="tsv" v-model="outputFormat" />
+            TSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="csv" v-model="outputFormat" />
+            CSV
+          </label>
+          <label class="format-option">
+            <input type="radio" value="markdown" v-model="outputFormat" />
+            MD
+          </label>
+          <label class="format-option">
+            <input type="radio" value="html" v-model="outputFormat" />
+            HTML
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="result-section">
+      <div class="input-header">
+        <div class="input-actions">
+          <button
+            class="btn btn-icon-small"
+            @click="copyToClipboard"
+            :disabled="copyLoading || !fullResult"
+            :class="{ loading: copyLoading }"
+            title="コピー（完全なデータ）"
+          >
+            <i :class="copyLoading ? 'mdi mdi-loading mdi-spin' : 'mdi mdi-content-copy'"></i>
+          </button>
+          <button
+            class="btn btn-icon-small"
+            @click="downloadResult"
+            :disabled="downloadLoading || !fullResult"
+            :class="{ loading: downloadLoading }"
+            title="ダウンロード（完全なデータ）"
+          >
+            <i :class="downloadLoading ? 'mdi mdi-loading mdi-spin' : 'mdi mdi-download'"></i>
+          </button>
+        </div>
+        <div class="result-header-right" style="display: flex; align-items: center; gap: 10px;">
+          <div class="delimiter-selector" style="display: inline-flex; width: auto; padding: 5px 10px;">
+            <label v-for="(label, key) in transformLabels" :key="key">
+              <input
+                type="checkbox"
+                :checked="transformTypes.includes(key)"
+                @change="($event: Event) => {
+                  const checked = ($event.target as HTMLInputElement).checked
+                  if (checked) transformTypes = [...transformTypes, key]
+                  else transformTypes = transformTypes.filter(t => t !== key)
+                }"
+              />
+              {{ label }}
+            </label>
+          </div>
+          <h3>実行結果<span v-if="conversionType" class="conversion-type">({{ conversionType }})</span></h3>
+        </div>
+      </div>
+      <textarea :value="displayResult" rows="10" readonly :placeholder="resultPlaceholder"></textarea>
+    </div>
+
+    <NotificationToast
+      :show="showNotificationFlag"
+      :message="notificationMessage"
+      :type="notificationType"
+    />
+  </div>
+</template>


### PR DESCRIPTION
## 変更内容

- **frame-table入力対応**: Unicode box-drawing文字（┌─┬─┐等）のframe-tableを入力形式として全画面に追加
  - `parseFrame()` 関数を追加（セパレータ行スキップ、`│`でのセル分割）
  - `detectDelimiter()` にframe-table検出ロジックを追加
  - 全画面（固定長変換、表変換、SQL INSERT）でframe-table入力に対応
- **DelimiterSelector共通化**: 入力形式セレクタをDRY原則に基づきコンポーネント内にカプセル化
  - 全画面で同じオプション（自動判別/TSV/CSV/SQL/MD/Frame表/HTML/固定長）を表示
- **SQL INSERT形式自動再生成**: 単一行/複数行の切替時に生成ボタン不要で自動再生成（100KB以下の場合）
- **INSERT形式オーバーレイ**: 実行結果テキストエリアの右下に配置

## テスト

- [x] ユニットテスト追加（parseFrame、frame-table検出、getDelimiter）
- [x] 手動テスト完了（ブラウザでframe-table入力→変換確認）
- [x] ビルド成功確認
- [x] 全305テスト通過