### PR TITLE
refactor: 入出力フォーマット選択肢の統一（SQL/MD分離）

### DIFF
--- a/__tests__/utils/converter.test.ts
+++ b/__tests__/utils/converter.test.ts
@@ -155,8 +155,12 @@ describe('Fixed Length Converter', () => {
       expect(getDelimiter('any data', 'csv')).toBe(',')
     })
 
-    it('should return pipe for pipe type', () => {
-      expect(getDelimiter('any data', 'pipe')).toBe('|')
+    it('should return pipe for sql type', () => {
+      expect(getDelimiter('any data', 'sql')).toBe('|')
+    })
+
+    it('should return pipe for md type', () => {
+      expect(getDelimiter('any data', 'md')).toBe('|')
     })
 
     it('should return frame delimiter for frame type', () => {

--- a/src/components/DelimiterSelector.vue
+++ b/src/components/DelimiterSelector.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { DelimiterType } from '../utils/converter'
 
 interface Option {
@@ -10,26 +11,36 @@ interface Props {
   modelValue: DelimiterType
   label?: string
   options?: Option[]
+  excludeAuto?: boolean
 }
 
-const DEFAULT_OPTIONS: Option[] = [
+const ALL_OPTIONS: Option[] = [
   { value: 'auto', label: '自動判別' },
   { value: 'tsv', label: 'TSV' },
   { value: 'csv', label: 'CSV' },
-  { value: 'pipe', label: 'SQL/MD' },
+  { value: 'sql', label: 'SQL' },
+  { value: 'md', label: 'MD' },
   { value: 'frame', label: 'Frame表' },
   { value: 'html', label: 'HTML' },
   { value: 'fixed', label: '固定長' },
 ]
 
-defineProps<Props>()
+const props = defineProps<Props>()
 defineEmits<{ (e: 'update:modelValue', value: DelimiterType): void }>()
+
+const resolvedOptions = computed(() => {
+  const base = props.options || ALL_OPTIONS
+  if (props.excludeAuto) {
+    return base.filter(opt => opt.value !== 'auto')
+  }
+  return base
+})
 </script>
 
 <template>
   <div class="delimiter-selector">
     <label v-if="label">{{ label }}</label>
-    <label v-for="opt in (options || DEFAULT_OPTIONS)" :key="opt.value">
+    <label v-for="opt in resolvedOptions" :key="opt.value">
       <input
         type="radio"
         :value="opt.value"

--- a/src/composables/useFileUpload.ts
+++ b/src/composables/useFileUpload.ts
@@ -1,7 +1,8 @@
 import { ref, computed } from 'vue'
 import type { Ref } from 'vue'
+import type { DelimiterType } from '../utils/converter'
 
-export type DelimiterType = 'csv' | 'tsv' | 'fixed' | 'auto' | 'pipe' | 'frame' | 'html'
+export type { DelimiterType }
 
 const CONTROL_CHAR_RATIO_THRESHOLD = 0.1
 const BINARY_CHECK_SIZE = 8000
@@ -88,8 +89,9 @@ export function useFileUpload(options: UseFileUploadOptions) {
         auto: '自動判別',
         csv: 'CSV',
         tsv: 'TSV',
+        sql: 'SQL',
+        md: 'MD',
         fixed: '固定長',
-        pipe: 'SQL/MD表',
         frame: 'Frame表',
         html: 'HTML',
       }

--- a/src/stores/converter.ts
+++ b/src/stores/converter.ts
@@ -43,5 +43,18 @@ export const useConverterStore = defineStore('converter', () => {
     clearColumnOptions
   }
 }, {
-  persist: true
+  persist: {
+    afterHydrate: (ctx) => {
+      const store = ctx.store as unknown as { delimiterType: string; outputFormat: string }
+      if (store.delimiterType === 'pipe') {
+        store.delimiterType = 'sql'
+      }
+      if (store.outputFormat === 'md-tbl') {
+        store.outputFormat = 'md'
+      }
+      if (store.outputFormat === 'html-tbl') {
+        store.outputFormat = 'html'
+      }
+    }
+  }
 })

--- a/src/stores/tableTransform.ts
+++ b/src/stores/tableTransform.ts
@@ -1,8 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import type { DelimiterType } from '../utils/converter'
+import type { DelimiterType, OutputFormat } from '../utils/converter'
 
-export type OutputFormat = 'csv' | 'tsv' | 'markdown' | 'html' | 'frame'
 export type TransformType = 'transpose' | 'flipVertical' | 'flipHorizontal'
 
 export const useTableTransformStore = defineStore('tableTransform', () => {
@@ -23,5 +22,12 @@ export const useTableTransformStore = defineStore('tableTransform', () => {
     clearInput
   }
 }, {
-  persist: true
+  persist: {
+    afterHydrate: (ctx) => {
+      const store = ctx.store as unknown as { outputFormat: string }
+      if (store.outputFormat === 'markdown') {
+        store.outputFormat = 'md'
+      }
+    }
+  }
 })

--- a/src/stores/tableTransform.ts
+++ b/src/stores/tableTransform.ts
@@ -24,7 +24,10 @@ export const useTableTransformStore = defineStore('tableTransform', () => {
 }, {
   persist: {
     afterHydrate: (ctx) => {
-      const store = ctx.store as unknown as { outputFormat: string }
+      const store = ctx.store as unknown as { inputFormat: string; outputFormat: string }
+      if (store.inputFormat === 'pipe') {
+        store.inputFormat = 'sql'
+      }
       if (store.outputFormat === 'markdown') {
         store.outputFormat = 'md'
       }

--- a/src/utils/converter.ts
+++ b/src/utils/converter.ts
@@ -6,9 +6,9 @@ export interface ColumnOption {
   padChar: string
 }
 
-export type DelimiterType = 'auto' | 'tsv' | 'csv' | 'pipe' | 'frame' | 'html' | 'fixed'
+export type DelimiterType = 'auto' | 'tsv' | 'csv' | 'sql' | 'md' | 'frame' | 'html' | 'fixed'
 
-export type OutputFormat = 'tsv' | 'csv' | 'fixed' | 'md-tbl' | 'html-tbl'
+export type OutputFormat = 'tsv' | 'csv' | 'sql' | 'md' | 'frame' | 'html' | 'fixed'
 
 // Unicode正規表現定数
 const UNICODE_SPACE_REGEX = /[\u00A0\u2000-\u200A\u202F\u205F]/g
@@ -80,7 +80,8 @@ export const getDelimiter = (data: string, type: DelimiterType): DetectedDelimit
   if (type === 'auto') return detectDelimiter(data)
   if (type === 'tsv') return '\t'
   if (type === 'csv') return ','
-  if (type === 'pipe') return '|'
+  if (type === 'sql') return '|'
+  if (type === 'md') return '|'
   if (type === 'frame') return '│'
   if (type === 'html') throw new Error("getDelimiter should not be called with type 'html'")
   // type === 'fixed' の場合はデリミタを検出しないため、呼び出すべきではない
@@ -98,7 +99,7 @@ export const getDelimiter = (data: string, type: DelimiterType): DetectedDelimit
  * @returns タブまたはカンマ
  */
 export const getOptionsDelimiter = (input: string, delimiterType: DelimiterType = 'auto'): '\t' | ',' => {
-  if (delimiterType === 'auto' || delimiterType === 'fixed' || delimiterType === 'pipe' || delimiterType === 'frame' || delimiterType === 'html') {
+  if (delimiterType === 'auto' || delimiterType === 'fixed' || delimiterType === 'sql' || delimiterType === 'md' || delimiterType === 'frame' || delimiterType === 'html') {
     return input.includes('\t') ? '\t' : ','
   }
   return delimiterType === 'tsv' ? '\t' : ','

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -3,7 +3,7 @@ import { ref, computed, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConverterStore } from '../stores/converter'
 import { parseColumnLengths, parseColumnOptions, getDelimiter, parseFixed, tsvToFixed as convertTsvToFixed } from '../utils/converter'
-import { parseDelimitedData, parsePipe, parseFrame, toCSV, toTSV, toMarkdown, toHtmlTable } from '../utils/delimited'
+import { parseDelimitedData, parsePipe, parseFrame, toCSV, toTSV, toPipe, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
 import { useNotification } from '../composables/useNotification'
 import DelimiterSelector from '../components/DelimiterSelector.vue'
 import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
@@ -115,11 +115,12 @@ const isDelimitedData = (data: string, expectedColumnCount: number): ParseResult
 
   // 明示的な形式が指定されている場合、その区切り文字がデータに含まれているか検証
   if (delimiterType.value !== 'auto') {
-    const expectedDelimiter = delimiterType.value === 'tsv' ? '\t' : delimiterType.value === 'csv' ? ',' : '|'
+    const expectedDelimiter = delimiterType.value === 'tsv' ? '\t' : delimiterType.value === 'csv' ? ',' : delimiterType.value === 'sql' || delimiterType.value === 'md' ? '|' : null
+    if (expectedDelimiter === null) return false
     const hasExpectedDelimiter = expectedColumnCount === 1 || trimmedData.includes(expectedDelimiter)
 
     if (!hasExpectedDelimiter) {
-      const formatName = delimiterType.value === 'tsv' ? 'TSV' : delimiterType.value === 'csv' ? 'CSV' : 'SQL/MD表'
+      const formatName = delimiterType.value === 'tsv' ? 'TSV' : delimiterType.value === 'csv' ? 'CSV' : 'SQL/MD'
       return { error: `入力形式が「${formatName}」に設定されていますが、${formatName === 'CSV' ? 'カンマ' : formatName === 'TSV' ? 'タブ' : 'パイプ'}が見つかりません。入力形式を見直してください。` }
     }
   }
@@ -164,10 +165,14 @@ const resultPlaceholder = computed(() => {
     return 'John      Tokyo     25\nAlice     NewYork   30\n(変換結果がここに表示されます)'
   } else if (outputFormat.value === 'tsv') {
     return 'John\tTokyo\t25\nAlice\tNewYork\t30\n(変換結果がここに表示されます)'
-  } else if (outputFormat.value === 'md-tbl') {
+  } else if (outputFormat.value === 'sql') {
+    return ' name | city    | age \n------+---------+-----\n John | Tokyo   | 25  \n Alice| NewYork | 30  \n(変換結果がここに表示されます)'
+  } else if (outputFormat.value === 'md') {
     return '| name | city    | age |\n| ---- | ------- | --- |\n| John | Tokyo   | 25  |\n| Alice| NewYork | 30  |\n(変換結果がここに表示されます)'
-  } else if (outputFormat.value === 'html-tbl') {
+  } else if (outputFormat.value === 'html') {
     return '<table>\n  <tr>\n    <th>name</th>\n    <th>city</th>\n    <th>age</th>\n  </tr>\n  ...\n</table>\n(変換結果がここに表示されます)'
+  } else if (outputFormat.value === 'frame') {
+    return '┌──────┬─────────┬─────┐\n│ name │ city    │ age │\n├──────┼─────────┼─────┤\n│ John │ Tokyo   │ 25  │\n└──────┴─────────┴─────┘\n(変換結果がここに表示されます)'
   } else {
     return 'John,Tokyo,25\nAlice,NewYork,30\n(変換結果がここに表示されます)'
   }
@@ -175,7 +180,7 @@ const resultPlaceholder = computed(() => {
 
 const handleDelimitedInput = (lengths: number[], parsedData: string[][], data: string) => {
   const delimiter = getDelimiter(data, delimiterType.value)
-  const inputType = delimiter === '\t' ? 'TSV' : delimiter === '|' ? 'SQL/MD表' : delimiter === '│' ? 'Frame表' : 'CSV'
+  const inputType = delimiter === '\t' ? 'TSV' : delimiter === '|' ? 'SQL/MD' : delimiter === '│' ? 'Frame表' : 'CSV'
 
   // useFirstRowAsHeaderがtrueの場合、1行目をスキップ
   let dataRows = parsedData
@@ -190,14 +195,18 @@ const handleDelimitedInput = (lengths: number[], parsedData: string[][], data: s
       ? parseColumnOptions(columnOptions.value)
       : lengths.map(() => ({ type: 'string' as const, padding: 'right' as const, padChar: ' ' }))
     fullResult.value = convertTsvToFixed(dataRows, lengths, options)
-  } else if (outputFormat.value === 'md-tbl') {
-    // TSV/CSV/SQL/MD表 → md-tbl
-    conversionType.value = `${inputType} → md-tbl`
+  } else if (outputFormat.value === 'sql') {
+    conversionType.value = `${inputType} → SQL`
+    fullResult.value = toPipe(dataRows)
+  } else if (outputFormat.value === 'md') {
+    conversionType.value = `${inputType} → MD`
     fullResult.value = toMarkdown(dataRows)
-  } else if (outputFormat.value === 'html-tbl') {
-    // TSV/CSV/SQL/MD表 → html-tbl
-    conversionType.value = `${inputType} → html-tbl`
+  } else if (outputFormat.value === 'html') {
+    conversionType.value = `${inputType} → HTML`
     fullResult.value = toHtmlTable(dataRows)
+  } else if (outputFormat.value === 'frame') {
+    conversionType.value = `${inputType} → Frame表`
+    fullResult.value = toFrame(dataRows)
   } else {
     // TSV/CSV/SQL/MD表 → TSV/CSV (区切り文字変換)
     const outputType = outputFormat.value === 'csv' ? 'CSV' : 'TSV'
@@ -207,7 +216,7 @@ const handleDelimitedInput = (lengths: number[], parsedData: string[][], data: s
 }
 
 const handleFixedWidthInput = (lengths: number[], data: string) => {
-  // 固定長 → TSV/CSV/md-tbl/html-tbl/固定長
+  // 固定長 → TSV/CSV/SQL/MD/HTML/Frame表/固定長
   const parsedData = parseFixed(data, lengths)
 
   let processedData = parsedData
@@ -231,12 +240,18 @@ const handleFixedWidthInput = (lengths: number[], data: string) => {
       ? parseColumnOptions(columnOptions.value)
       : lengths.map(() => ({ type: 'string' as const, padding: 'right' as const, padChar: ' ' }))
     fullResult.value = convertTsvToFixed(processedData, lengths, options)
-  } else if (outputFormat.value === 'md-tbl') {
-    conversionType.value = '固定長 → md-tbl'
+  } else if (outputFormat.value === 'sql') {
+    conversionType.value = '固定長 → SQL'
+    fullResult.value = toPipe(processedData)
+  } else if (outputFormat.value === 'md') {
+    conversionType.value = '固定長 → MD'
     fullResult.value = toMarkdown(processedData)
-  } else if (outputFormat.value === 'html-tbl') {
-    conversionType.value = '固定長 → html-tbl'
+  } else if (outputFormat.value === 'html') {
+    conversionType.value = '固定長 → HTML'
     fullResult.value = toHtmlTable(processedData)
+  } else if (outputFormat.value === 'frame') {
+    conversionType.value = '固定長 → Frame表'
+    fullResult.value = toFrame(processedData)
   } else {
     const outputType = outputFormat.value === 'csv' ? 'CSV' : 'TSV'
     conversionType.value = `固定長 → ${outputType}`
@@ -585,32 +600,6 @@ const clearDataBody = () => {
 
       <div class="format-selectors">
         <div class="format-group">
-          <span class="format-label">入力:</span>
-          <label class="format-option">
-            <input type="radio" value="auto" v-model="delimiterType" />
-            自動
-          </label>
-          <label class="format-option">
-            <input type="radio" value="tsv" v-model="delimiterType" />
-            TSV
-          </label>
-          <label class="format-option">
-            <input type="radio" value="csv" v-model="delimiterType" />
-            CSV
-          </label>
-          <label class="format-option">
-            <input type="radio" value="pipe" v-model="delimiterType" />
-            SQL/MD
-          </label>
-          <label class="format-option">
-            <input type="radio" value="fixed" v-model="delimiterType" />
-            固定長
-          </label>
-        </div>
-
-        <span class="format-arrow"><i class="mdi mdi-arrow-right"></i></span>
-
-        <div class="format-group">
           <span class="format-label">出力:</span>
           <label class="format-option">
             <input type="radio" value="fixed" v-model="outputFormat" />
@@ -625,12 +614,20 @@ const clearDataBody = () => {
             CSV
           </label>
           <label class="format-option">
-            <input type="radio" value="md-tbl" v-model="outputFormat" />
-            md-tbl
+            <input type="radio" value="sql" v-model="outputFormat" />
+            SQL
           </label>
           <label class="format-option">
-            <input type="radio" value="html-tbl" v-model="outputFormat" />
-            html-tbl
+            <input type="radio" value="md" v-model="outputFormat" />
+            MD
+          </label>
+          <label class="format-option">
+            <input type="radio" value="frame" v-model="outputFormat" />
+            Frame表
+          </label>
+          <label class="format-option">
+            <input type="radio" value="html" v-model="outputFormat" />
+            HTML
           </label>
         </div>
       </div>

--- a/src/views/FixedLengthConverter.vue
+++ b/src/views/FixedLengthConverter.vue
@@ -3,7 +3,7 @@ import { ref, computed, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useConverterStore } from '../stores/converter'
 import { parseColumnLengths, parseColumnOptions, getDelimiter, parseFixed, tsvToFixed as convertTsvToFixed } from '../utils/converter'
-import { parseDelimitedData, parsePipe, parseFrame, toCSV, toTSV, toPipe, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
+import { parseDelimitedData, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toPipe, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
 import { useNotification } from '../composables/useNotification'
 import DelimiterSelector from '../components/DelimiterSelector.vue'
 import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
@@ -115,13 +115,20 @@ const isDelimitedData = (data: string, expectedColumnCount: number): ParseResult
 
   // 明示的な形式が指定されている場合、その区切り文字がデータに含まれているか検証
   if (delimiterType.value !== 'auto') {
-    const expectedDelimiter = delimiterType.value === 'tsv' ? '\t' : delimiterType.value === 'csv' ? ',' : delimiterType.value === 'sql' || delimiterType.value === 'md' ? '|' : null
+    // HTMLは区切り文字ベースではないため個別に処理
+    if (delimiterType.value === 'html') {
+      const rows = parseHtmlTable(trimmedData)
+      if (rows.length === 0) return { error: '入力形式が「HTML」に設定されていますが、有効な<table>が見つかりません。' }
+      return { data: rows }
+    }
+    const expectedDelimiter = delimiterType.value === 'tsv' ? '\t' : delimiterType.value === 'csv' ? ',' : delimiterType.value === 'sql' || delimiterType.value === 'md' ? '|' : delimiterType.value === 'frame' ? '│' : null
     if (expectedDelimiter === null) return false
     const hasExpectedDelimiter = expectedColumnCount === 1 || trimmedData.includes(expectedDelimiter)
 
     if (!hasExpectedDelimiter) {
-      const formatName = delimiterType.value === 'tsv' ? 'TSV' : delimiterType.value === 'csv' ? 'CSV' : 'SQL/MD'
-      return { error: `入力形式が「${formatName}」に設定されていますが、${formatName === 'CSV' ? 'カンマ' : formatName === 'TSV' ? 'タブ' : 'パイプ'}が見つかりません。入力形式を見直してください。` }
+      const formatName = delimiterType.value === 'tsv' ? 'TSV' : delimiterType.value === 'csv' ? 'CSV' : delimiterType.value === 'frame' ? 'Frame表' : 'SQL/MD'
+      const charName = formatName === 'CSV' ? 'カンマ' : formatName === 'TSV' ? 'タブ' : formatName === 'Frame表' ? '罫線' : 'パイプ'
+      return { error: `入力形式が「${formatName}」に設定されていますが、${charName}が見つかりません。入力形式を見直してください。` }
     }
   }
 
@@ -179,8 +186,10 @@ const resultPlaceholder = computed(() => {
 })
 
 const handleDelimitedInput = (lengths: number[], parsedData: string[][], data: string) => {
-  const delimiter = getDelimiter(data, delimiterType.value)
-  const inputType = delimiter === '\t' ? 'TSV' : delimiter === '|' ? 'SQL/MD' : delimiter === '│' ? 'Frame表' : 'CSV'
+  const inputType = delimiterType.value === 'html' ? 'HTML' : (() => {
+    const d = getDelimiter(data, delimiterType.value)
+    return d === '\t' ? 'TSV' : d === '|' ? 'SQL/MD' : d === '│' ? 'Frame表' : 'CSV'
+  })()
 
   // useFirstRowAsHeaderがtrueの場合、1行目をスキップ
   let dataRows = parsedData

--- a/src/views/TableTransformer.vue
+++ b/src/views/TableTransformer.vue
@@ -2,7 +2,7 @@
 import { ref, computed, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
 import { transpose, flipVertical, flipHorizontal } from '../utils/tableTransform'
-import { parseCSV, parseTSV, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
+import { parseCSV, parseTSV, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toPipe, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
 import { detectDelimiter } from '../utils/converter'
 import { useTableTransformStore } from '../stores/tableTransform'
 import { useNotification } from '../composables/useNotification'
@@ -10,8 +10,8 @@ import { useTruncatedDisplay } from '../composables/useTruncatedDisplay'
 import { useFileUpload } from '../composables/useFileUpload'
 import NotificationToast from '../components/NotificationToast.vue'
 import DelimiterSelector from '../components/DelimiterSelector.vue'
-import type { OutputFormat, TransformType } from '../stores/tableTransform'
-import type { DelimiterType } from '../utils/converter'
+import type { OutputFormat, DelimiterType } from '../utils/converter'
+import type { TransformType } from '../stores/tableTransform'
 
 const store = useTableTransformStore()
 const { inputText, inputFormat, outputFormat, transformTypes } = storeToRefs(store)
@@ -58,7 +58,8 @@ const parseInput = (text: string, format: DelimiterType): string[][] => {
 
   if (format === 'tsv') return parseTSV(text)
   if (format === 'csv') return parseCSV(text)
-  if (format === 'pipe') return parsePipe(text)
+  if (format === 'sql') return parsePipe(text)
+  if (format === 'md') return parsePipe(text)
   if (format === 'frame') return parseFrame(text)
   return parseTSV(text)
 }
@@ -66,7 +67,8 @@ const parseInput = (text: string, format: DelimiterType): string[][] => {
 const formatOutput = (data: string[][], format: OutputFormat): string => {
   if (format === 'csv') return toCSV(data)
   if (format === 'tsv') return toTSV(data)
-  if (format === 'markdown') return toMarkdown(data)
+  if (format === 'sql') return toPipe(data)
+  if (format === 'md') return toMarkdown(data)
   if (format === 'html') return toHtmlTable(data)
   if (format === 'frame') return toFrame(data)
   return toTSV(data)
@@ -89,7 +91,8 @@ const transformAll = (data: string[][], types: TransformType[]): string[][] => {
 
 const resultPlaceholder = computed(() => {
   if (outputFormat.value === 'csv') return 'name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\n(変換結果がここに表示されます)'
-  if (outputFormat.value === 'markdown') return '| name | age | city |\n| ---- | --- | ---- |\n| Alice | 30 | Tokyo |\n| Bob | 25 | Osaka |\n(変換結果がここに表示されます)'
+  if (outputFormat.value === 'sql') return ' name | age | city  \n------+-----+-------\n Alice| 30  | Tokyo \n Bob  | 25  | Osaka \n(変換結果がここに表示されます)'
+  if (outputFormat.value === 'md') return '| name | age | city |\n| ---- | --- | ---- |\n| Alice | 30 | Tokyo |\n| Bob | 25 | Osaka |\n(変換結果がここに表示されます)'
   if (outputFormat.value === 'html') return '<table>\n  <tr>\n    <th>name</th>\n    <th>age</th>\n    <th>city</th>\n  </tr>\n  ...\n</table>\n(変換結果がここに表示されます)'
   if (outputFormat.value === 'frame') return '┌──────┬─────┬───────┐\n│ name │ age │ city  │\n├──────┼─────┼───────┤\n│Alice │ 30  │ Tokyo │\n│ Bob  │ 25  │ Osaka │\n└──────┴─────┴───────┘\n(変換結果がここに表示されます)'
   return 'name\tage\tcity\nAlice\t30\tTokyo\nBob\t25\tOsaka\n(変換結果がここに表示されます)'
@@ -123,9 +126,9 @@ const convert = async () => {
 
     const detected = detectDelimiter(data)
     const inputType = inputFormat.value === 'auto'
-      ? (detected === '\t' ? 'TSV' : detected === ',' ? 'CSV' : detected === '|' ? 'SQL/MD表' : detected === '│' ? 'Frame表' : 'TSV')
-      : inputFormat.value === 'pipe' ? 'SQL/MD' : inputFormat.value === 'frame' ? 'Frame表' : inputFormat.value.toUpperCase()
-    const outputType = outputFormat.value === 'markdown' ? 'Markdown' : outputFormat.value === 'frame' ? 'Frame表' : outputFormat.value.toUpperCase()
+      ? (detected === '\t' ? 'TSV' : detected === ',' ? 'CSV' : detected === '|' ? 'SQL/MD' : detected === '│' ? 'Frame表' : 'TSV')
+      : inputFormat.value === 'sql' ? 'SQL' : inputFormat.value === 'md' ? 'MD' : inputFormat.value === 'frame' ? 'Frame表' : inputFormat.value.toUpperCase()
+    const outputType = outputFormat.value === 'sql' ? 'SQL' : outputFormat.value === 'md' ? 'MD' : outputFormat.value === 'frame' ? 'Frame表' : outputFormat.value.toUpperCase()
     const typeLabels = transformTypes.value.map(t => transformLabels[t]).join('+')
     conversionType.value = `${typeLabels} (${inputType} → ${outputType})`
   } catch (error) {
@@ -149,7 +152,7 @@ const copyToClipboard = () => {
 
 const downloadResult = () => {
   downloadLoading.value = true
-  const extMap: Record<OutputFormat, string> = { csv: '.csv', tsv: '.tsv', markdown: '.md', html: '.html', frame: '.txt' }
+  const extMap: Record<OutputFormat, string> = { csv: '.csv', tsv: '.tsv', sql: '.txt', md: '.md', html: '.html', frame: '.txt', fixed: '.txt' }
   const blob = new Blob([fullResult.value], { type: 'text/plain' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
@@ -277,16 +280,20 @@ const clearInputData = () => {
             CSV
           </label>
           <label class="format-option">
-            <input type="radio" value="markdown" v-model="outputFormat" />
-            MD
+            <input type="radio" value="sql" v-model="outputFormat" />
+            SQL
           </label>
           <label class="format-option">
-            <input type="radio" value="html" v-model="outputFormat" />
-            HTML
+            <input type="radio" value="md" v-model="outputFormat" />
+            MD
           </label>
           <label class="format-option">
             <input type="radio" value="frame" v-model="outputFormat" />
             Frame表
+          </label>
+          <label class="format-option">
+            <input type="radio" value="html" v-model="outputFormat" />
+            HTML
           </label>
         </div>
       </div>


### PR DESCRIPTION
## 変更内容

- `DelimiterType`の`pipe`を`sql`/`md`に分離し、SQLとMDを独立した選択肢に変更
- `OutputFormat`を`converter.ts`に統一定義（`stores/tableTransform.ts`の重複定義を削除）
- 入力と出力のフォーマット選択肢を原則対称化（入力 = 出力 + 「自動」）
- FixedLengthConverterの変換行から重複する入力フォーマットラジオボタンを削除
- TableTransformerの出力を6種（TSV, CSV, SQL, MD, Frame表, HTML）に拡充
- FixedLengthConverterの出力を7種（固定長含む）に拡充
- 永続化データのマイグレーション追加（`pipe`→`sql`, `markdown`→`md`, `md-tbl`→`md`, `html-tbl`→`html`）
- `useFileUpload.ts`の独自`DelimiterType`定義を廃止し`converter.ts`からimport

## テスト

- [x] ユニットテスト 310件すべて通過
- [x] ビルド成功確認

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>