### PR TITLE
fix: PR#91 レビュー指摘対応 - 全角文字表示幅計算修正

### DIFF
--- a/__tests__/utils/delimited.test.ts
+++ b/__tests__/utils/delimited.test.ts
@@ -373,6 +373,18 @@ describe('Delimited Data Converter', () => {
       expect(lines[3]).toBe('│太郎│25  │')
       expect(lines[4]).toBe('└────┴────┘')
     })
+
+    it('絵文字を含むデータの幅を正しく計算する', () => {
+      const data = [['item', '\u{1F431}'], ['apple', 'OK']]
+      const result = toFrame(data)
+      const lines = result.split('\n')
+      // colWidths: [5, 2] (apple=5, cat emoji=2)
+      expect(lines[0]).toBe('┌─────┬──┐')
+      expect(lines[1]).toBe('│item │\u{1F431}│')
+      expect(lines[2]).toBe('├─────┼──┤')
+      expect(lines[3]).toBe('│apple│OK│')
+      expect(lines[4]).toBe('└─────┴──┘')
+    })
   })
 
   describe('toHtmlTable', () => {

--- a/__tests__/utils/delimited.test.ts
+++ b/__tests__/utils/delimited.test.ts
@@ -288,6 +288,15 @@ describe('Delimited Data Converter', () => {
       const result = toPipe(data)
       expect(result).toBe('')
     })
+
+    it('全角文字を含むデータの幅を正しく計算する', () => {
+      const data = [['名前', '値'], ['太郎', '100']]
+      const result = toPipe(data)
+      const lines = result.split('\n')
+      expect(lines[0]).toBe(' 名前 | 値  ')
+      expect(lines[1]).toBe('------+-----')
+      expect(lines[2]).toBe(' 太郎 | 100 ')
+    })
   })
 
   describe('toMarkdown', () => {
@@ -313,6 +322,15 @@ describe('Delimited Data Converter', () => {
       const lines = result.split('\n')
       expect(lines[0]).toBe('| a   | b   |')
       expect(lines[1]).toBe('| --- | --- |')
+    })
+
+    it('全角文字を含むデータの幅を正しく計算する', () => {
+      const data = [['名前', '値'], ['太郎', '100']]
+      const result = toMarkdown(data)
+      const lines = result.split('\n')
+      expect(lines[0]).toBe('| 名前 | 値  |')
+      expect(lines[1]).toBe('| ---- | --- |')
+      expect(lines[2]).toBe('| 太郎 | 100 |')
     })
   })
 
@@ -343,6 +361,17 @@ describe('Delimited Data Converter', () => {
       expect(lines[1]).toBe('│a│b│')
       expect(lines[2]).toBe('└─┴─┘')
       expect(lines.length).toBe(3)
+    })
+
+    it('全角文字を含むデータの幅を正しく計算する', () => {
+      const data = [['名前', '年齢'], ['太郎', '25']]
+      const result = toFrame(data)
+      const lines = result.split('\n')
+      expect(lines[0]).toBe('┌────┬────┐')
+      expect(lines[1]).toBe('│名前│年齢│')
+      expect(lines[2]).toBe('├────┼────┤')
+      expect(lines[3]).toBe('│太郎│25  │')
+      expect(lines[4]).toBe('└────┴────┘')
     })
   })
 

--- a/src/utils/delimited.ts
+++ b/src/utils/delimited.ts
@@ -18,11 +18,9 @@ function visualWidth(str: string): number {
       (cp >= 0xFE30 && cp <= 0xFE6F) ||  // CJK Compatibility Forms
       (cp >= 0xFF01 && cp <= 0xFF60) ||  // Fullwidth Forms
       (cp >= 0xFFE0 && cp <= 0xFFE6) ||  // Fullwidth Signs
-      (cp >= 0x20000 && cp <= 0x2A6DF) ||  // CJK Unified Extension B
-      (cp >= 0x2A700 && cp <= 0x2B73F) ||  // CJK Unified Extension C
-      (cp >= 0x2B740 && cp <= 0x2B81F) ||  // CJK Unified Extension D
-      (cp >= 0x2B820 && cp <= 0x2CEAF) ||  // CJK Unified Extension E
-      (cp >= 0x2CEB0 && cp <= 0x2EBEF)     // CJK Unified Extension F
+      (cp >= 0x20000 && cp <= 0x2FFFF) ||  // CJK Plane 2 (Extensions B-F, etc.)
+      (cp >= 0x30000 && cp <= 0x3FFFF) ||  // CJK Plane 3 (Extensions G-H, etc.)
+      (cp >= 0x1F300 && cp <= 0x1FAFF)     // Emojis
     ) {
       width += 2;
     } else {

--- a/src/utils/delimited.ts
+++ b/src/utils/delimited.ts
@@ -1,6 +1,47 @@
 import { parse, unparse } from 'papaparse';
 
 /**
+ * 文字列の表示幅を計算する（全角文字を2カラム分として扱う）
+ */
+function visualWidth(str: string): number {
+  let width = 0;
+  for (const char of str) {
+    const cp = char.codePointAt(0)!;
+    if (
+      (cp >= 0x1100 && cp <= 0x115F) ||  // Hangul Jamo
+      (cp >= 0x2E80 && cp <= 0x303E) ||  // CJK Misc
+      (cp >= 0x3040 && cp <= 0x33BF) ||  // Hiragana, Katakana, CJK Symbols
+      (cp >= 0x3400 && cp <= 0x4DBF) ||  // CJK Unified Ideographs Extension A
+      (cp >= 0x4E00 && cp <= 0x9FFF) ||  // CJK Unified Ideographs
+      (cp >= 0xAC00 && cp <= 0xD7A3) ||  // Hangul Syllables
+      (cp >= 0xF900 && cp <= 0xFAFF) ||  // CJK Compatibility Ideographs
+      (cp >= 0xFE30 && cp <= 0xFE6F) ||  // CJK Compatibility Forms
+      (cp >= 0xFF01 && cp <= 0xFF60) ||  // Fullwidth Forms
+      (cp >= 0xFFE0 && cp <= 0xFFE6) ||  // Fullwidth Signs
+      (cp >= 0x20000 && cp <= 0x2A6DF) ||  // CJK Unified Extension B
+      (cp >= 0x2A700 && cp <= 0x2B73F) ||  // CJK Unified Extension C
+      (cp >= 0x2B740 && cp <= 0x2B81F) ||  // CJK Unified Extension D
+      (cp >= 0x2B820 && cp <= 0x2CEAF) ||  // CJK Unified Extension E
+      (cp >= 0x2CEB0 && cp <= 0x2EBEF)     // CJK Unified Extension F
+    ) {
+      width += 2;
+    } else {
+      width += 1;
+    }
+  }
+  return width;
+}
+
+/**
+ * 文字列を視覚幅に合わせて右パディングする
+ */
+function visualPadEnd(str: string, targetWidth: number, padChar: string = ' '): string {
+  const currentWidth = visualWidth(str);
+  const padCount = targetWidth - currentWidth;
+  return padCount > 0 ? str + padChar.repeat(padCount) : str;
+}
+
+/**
  * 区切り文字データをパースする（共通関数）
  */
 function parseDelimited(input: string, delimiter: ',' | '\t'): string[][] {
@@ -167,7 +208,7 @@ export function toPipe(data: string[][]): string {
   // 各列の最大幅を計算
   const colWidths = data.reduce<number[]>((widths, row) => {
     row.forEach((cell, i) => {
-      widths[i] = Math.max(widths[i] || 0, (cell || '').length);
+      widths[i] = Math.max(widths[i] || 0, visualWidth(cell || ''));
     });
     return widths;
   }, []);
@@ -178,7 +219,7 @@ export function toPipe(data: string[][]): string {
     const row = data[rowIndex];
     const paddedCols = row.map((col, i) => {
       const width = colWidths[i] || 0;
-      return (col || '').padEnd(width, ' ');
+      return visualPadEnd(col || '', width);
     });
     lines.push(' ' + paddedCols.join(' | ') + ' ');
 
@@ -200,7 +241,7 @@ export function toFrame(data: string[][]): string {
 
   const colWidths = data.reduce<number[]>((widths, row) => {
     row.forEach((cell, i) => {
-      const cellLen = (cell || '').length;
+      const cellLen = visualWidth(cell || '');
       widths[i] = Math.max(widths[i] || 1, cellLen);
     });
     return widths;
@@ -215,7 +256,7 @@ export function toFrame(data: string[][]): string {
     const row = data[rowIndex];
     const paddedCols = row.map((col, i) => {
       const width = colWidths[i] || 1;
-      return (col || '').padEnd(width, ' ');
+      return visualPadEnd(col || '', width);
     });
     lines.push('│' + paddedCols.join('│') + '│');
 
@@ -237,7 +278,7 @@ export function toMarkdown(data: string[][]): string {
   // 各列の最大幅を計算（最低3文字）
   const colWidths = data.reduce<number[]>((widths, row) => {
     row.forEach((cell, i) => {
-      const cellLen = (cell || '').length;
+      const cellLen = visualWidth(cell || '');
       widths[i] = Math.max(widths[i] || 3, cellLen);
     });
     return widths;
@@ -249,7 +290,7 @@ export function toMarkdown(data: string[][]): string {
     const row = data[rowIndex];
     const paddedCols = row.map((col, i) => {
       const width = colWidths[i] || 3;
-      return (col || '').padEnd(width, ' ');
+      return visualPadEnd(col || '', width);
     });
     lines.push('| ' + paddedCols.join(' | ') + ' |');
 


### PR DESCRIPTION
## 概要

PR#91のレビュー指摘に対応しました。

## 対応内容

- `visualWidth`関数を導入し、全角文字（CJK、ひらがな、カタカナ等）を2カラム分として計算
- `visualPadEnd`関数で視覚幅に基づくパディングを実装
- `toFrame`、`toMarkdown`、`toPipe`の3関数で`.length`/`.padEnd()`を新関数に置換
- 全角文字テストケース3件追加

## 対応しなかった指摘

- `parseHtmlTable`のDOMParser移行（TASK-28: 別PRで対応予定）

## 関連PR

- 元のPR: #91

## テスト

- [x] 全角文字テスト3件追加（toFrame、toMarkdown、toPipe）
- [x] 全313テスト通過
- [x] ビルド成功確認