### PR TITLE
fix: 表変換でオプション未選択（形式のみの変換）を許容

### DIFF
--- a/__tests__/utils/tableTransform.test.ts
+++ b/__tests__/utils/tableTransform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { transpose, flipVertical, flipHorizontal } from '../../src/utils/tableTransform'
+import { transpose, flipVertical, flipHorizontal, transformAll } from '../../src/utils/tableTransform'
 
 describe('tableTransform', () => {
   describe('transpose', () => {
@@ -97,6 +97,46 @@ describe('tableTransform', () => {
 
     it('should handle rows with single column', () => {
       expect(flipHorizontal([['a'], ['b']])).toEqual([['a'], ['b']])
+    })
+  })
+
+  describe('transformAll', () => {
+    it('should return data unchanged when no transform types are given', () => {
+      const data = [
+        ['a', 'b'],
+        ['c', 'd']
+      ]
+      expect(transformAll(data, [])).toEqual(data)
+    })
+
+    it('should apply a single transform', () => {
+      const data = [
+        ['a', 'b'],
+        ['c', 'd']
+      ]
+      expect(transformAll(data, ['transpose'])).toEqual([
+        ['a', 'c'],
+        ['b', 'd']
+      ])
+    })
+
+    it('should apply multiple transforms in the given order', () => {
+      const data = [
+        ['a', 'b'],
+        ['c', 'd']
+      ]
+      // transpose -> flipVertical
+      expect(transformAll(data, ['transpose', 'flipVertical'])).toEqual([
+        ['b', 'd'],
+        ['a', 'c']
+      ])
+    })
+
+    it('should not modify the original array', () => {
+      const data = [['a', 'b'], ['c', 'd']]
+      const result = transformAll(data, ['flipHorizontal'])
+      expect(data).toEqual([['a', 'b'], ['c', 'd']])
+      expect(result).toEqual([['b', 'a'], ['d', 'c']])
     })
   })
 })

--- a/docs/changelog/unreleased.md
+++ b/docs/changelog/unreleased.md
@@ -1,0 +1,41 @@
+# v1.1.0 (2026-05-16)
+
+## New Features
+
+- SQL表形式（PostgreSQLパイプ/MySQL表形式）とMarkdown表形式の入出力対応を追加
+- html-tbl出力形式を追加（Markdown出力はmd-tblに名称変更）
+- Frame表出力形式（toFrame関数）を追加
+- プリセット削除時に2段階確認ダイアログを追加
+- 入力元の形式を自動検出し、不一致時にエラーメッセージを表示
+
+## Bug Fixes
+
+- App.vueのラッパーdiv削除によるレイアウト問題を解決
+- 固定長→固定長変換でヘッダーが統一されない問題を修正
+- 固定長入力でuseFirstRowAsHeaderが正しく適用されない問題を修正
+- usePresetCache.tsでNull合体演算子を使用した防御的実装
+- 削除確認状態をプリセット名と紐付けて選択変更時の誤操作を防止
+- 1カラムデータの場合に区切り文字存在チェックをスキップ
+- DelimiterSelectorにoptions propを追加しDEFAULT_OPTIONSにフォールバック
+- parseFrame正規表現から罫線文字を除去し空データ行のスキップを修正
+- inputType表示にFrame表検出を追加、detectDelimiter重複呼び出しを解消
+- isDelimitedDataでframe/html入力形式が正しく判定されない問題を修正
+- handleDelimitedInputでhtml選択時のgetDelimiter例外を回避
+- tableTransform.tsにinputFormat(pipe→sql)マイグレーションを追加
+- toFrame/toMarkdown/toPipeで全角文字を含むデータの表示幅計算を修正（visualWidth/visualPadEnd関数を導入）
+- visualWidth関数のUnicode範囲を拡張（絵文字、CJK拡張G-H対応）
+- 表変換で変換オプション未選択時にエラーになる問題を修正（形式のみの変換を許容）
+
+## Changes
+
+- PresetDataの型定義をユニオン型に変更
+- JSON.parseの結果に型チェックを追加
+- プリセット上書き時に確認ダイアログを追加
+- 変換ボタンの右に入力元・出力先形式選択を移動するUI改善
+
+## Refactoring
+
+- SettingsPage.vueの通知ロジックを共通化
+- handleFixedWidthInputの変数を統合してコードを簡潔に
+- OutputFormat型を共通化して重複を解消
+- TableTransformerの冗長な入力形式セクションを削除

--- a/src/stores/tableTransform.ts
+++ b/src/stores/tableTransform.ts
@@ -1,8 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import type { DelimiterType, OutputFormat } from '../utils/converter'
-
-export type TransformType = 'transpose' | 'flipVertical' | 'flipHorizontal'
+import type { TransformType } from '../utils/tableTransform'
 
 export const useTableTransformStore = defineStore('tableTransform', () => {
   const inputText = ref('')

--- a/src/utils/tableTransform.ts
+++ b/src/utils/tableTransform.ts
@@ -1,3 +1,5 @@
+export type TransformType = 'transpose' | 'flipVertical' | 'flipHorizontal'
+
 /**
  * 2次元配列の縦横変換（転置）
  * 行数が異なる場合は空文字で埋める
@@ -31,4 +33,17 @@ export function flipVertical(data: string[][]): string[][] {
  */
 export function flipHorizontal(data: string[][]): string[][] {
   return data.map(row => [...row].reverse())
+}
+
+/**
+ * 複数の変換を指定された順に適用する
+ * types が空の場合は元データをそのまま返す（形式変換のみ）
+ */
+export function transformAll(data: string[][], types: TransformType[]): string[][] {
+  return types.reduce((acc, type) => {
+    if (type === 'transpose') return transpose(acc)
+    if (type === 'flipVertical') return flipVertical(acc)
+    if (type === 'flipHorizontal') return flipHorizontal(acc)
+    return acc
+  }, data)
 }

--- a/src/views/TableTransformer.vue
+++ b/src/views/TableTransformer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, toRef } from 'vue'
 import { storeToRefs } from 'pinia'
-import { transpose, flipVertical, flipHorizontal } from '../utils/tableTransform'
+import { transformAll } from '../utils/tableTransform'
 import { parseCSV, parseTSV, parsePipe, parseFrame, parseHtmlTable, toCSV, toTSV, toPipe, toMarkdown, toHtmlTable, toFrame } from '../utils/delimited'
 import { detectDelimiter } from '../utils/converter'
 import { useTableTransformStore } from '../stores/tableTransform'
@@ -11,7 +11,7 @@ import { useFileUpload } from '../composables/useFileUpload'
 import NotificationToast from '../components/NotificationToast.vue'
 import DelimiterSelector from '../components/DelimiterSelector.vue'
 import type { OutputFormat, DelimiterType } from '../utils/converter'
-import type { TransformType } from '../stores/tableTransform'
+import type { TransformType } from '../utils/tableTransform'
 
 const store = useTableTransformStore()
 const { inputText, inputFormat, outputFormat, transformTypes } = storeToRefs(store)
@@ -80,15 +80,6 @@ const transformLabels: Record<TransformType, string> = {
   flipHorizontal: '左右反転'
 }
 
-const transformAll = (data: string[][], types: TransformType[]): string[][] => {
-  return types.reduce((acc, type) => {
-    if (type === 'transpose') return transpose(acc)
-    if (type === 'flipVertical') return flipVertical(acc)
-    if (type === 'flipHorizontal') return flipHorizontal(acc)
-    return acc
-  }, data)
-}
-
 const resultPlaceholder = computed(() => {
   if (outputFormat.value === 'csv') return 'name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\n(変換結果がここに表示されます)'
   if (outputFormat.value === 'sql') return ' name | age | city  \n------+-----+-------\n Alice| 30  | Tokyo \n Bob  | 25  | Osaka \n(変換結果がここに表示されます)'
@@ -117,10 +108,6 @@ const convert = async () => {
       throw new Error('有効なデータが見つかりません')
     }
 
-    if (transformTypes.value.length === 0) {
-      throw new Error('変換形式を1つ以上選択してください')
-    }
-
     const transformed = transformAll(parsed, transformTypes.value)
     fullResult.value = formatOutput(transformed, outputFormat.value)
 
@@ -129,7 +116,9 @@ const convert = async () => {
       ? (detected === '\t' ? 'TSV' : detected === ',' ? 'CSV' : detected === '|' ? 'SQL/MD' : detected === '│' ? 'Frame表' : 'TSV')
       : inputFormat.value === 'sql' ? 'SQL' : inputFormat.value === 'md' ? 'MD' : inputFormat.value === 'frame' ? 'Frame表' : inputFormat.value.toUpperCase()
     const outputType = outputFormat.value === 'sql' ? 'SQL' : outputFormat.value === 'md' ? 'MD' : outputFormat.value === 'frame' ? 'Frame表' : outputFormat.value.toUpperCase()
-    const typeLabels = transformTypes.value.map(t => transformLabels[t]).join('+')
+    const typeLabels = transformTypes.value.length > 0
+      ? transformTypes.value.map(t => transformLabels[t]).join('+')
+      : '形式変換のみ'
     conversionType.value = `${typeLabels} (${inputType} → ${outputType})`
   } catch (error) {
     fullResult.value = 'エラー: ' + (error as Error).message


### PR DESCRIPTION
## 変更内容

dev → main のマージPR。origin/dev にマージされた PR #93 を main に取り込みます。

### PR #93: 表変換でオプション未選択（形式のみの変換）を許容

表変換機能で、変換オプション（縦横変換/上下反転/左右反転）を1つも選ばない「形式のみの変換」を許容するよう修正しました。従来はオプション必須でエラーになっていましたが、形式だけ変えたい需要（TSV→Markdown 等）に対応します。

- `TableTransformer.vue`: オプション未選択時のバリデーションを削除、未選択時の結果ラベルを「形式変換のみ」と表示
- `utils/tableTransform.ts`: `transformAll` を追加（utils 切り出し）、`TransformType` 型もここへ移動
- `stores/tableTransform.ts`: `TransformType` を utils からの import に変更
- テスト: `transformAll` のユニットテスト追加（空配列・単一・複数順序・非破壊）

## テスト

- [x] 全318テストパス
- [x] typecheck・build 成功
- [x] PR #93 で画面動作確認済み